### PR TITLE
[RoomFinder] show error message, add missing localisations

### DIFF
--- a/TUM Campus App/Base.lproj/Localizable.strings
+++ b/TUM Campus App/Base.lproj/Localizable.strings
@@ -42,6 +42,7 @@
 "Cafeteria Map"  = "Cafeteria Map";
 "Search Rooms" = "Search Rooms";
 "Room Finder" = "Room Finder";
+"Unable to find room" = "Unable to find room '%@'";
 "No Menu" = "No Menu";
 
 "animation showing the token activation" = "animation showing the token activation";

--- a/TUM Campus App/Cafeteria/MealPlanTableViewController.swift
+++ b/TUM Campus App/Cafeteria/MealPlanTableViewController.swift
@@ -55,7 +55,7 @@ final class MealPlanTableViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         if menus.isEmpty {
-            setBackgroundLabel(with: "No Menu".localized)
+            setBackgroundLabel(withText: "No Menu".localized)
         }
         return menus.count
     }

--- a/TUM Campus App/Calendar/CalendarTableViewController.swift
+++ b/TUM Campus App/Calendar/CalendarTableViewController.swift
@@ -49,7 +49,7 @@ final class CalendarTableViewController: UITableViewController, EntityTableViewC
                 self?.reload()
             default: break
             }
-            self?.setBackgroundLabel(with: error.localizedDescription)
+            self?.setBackgroundLabel(withText: error.localizedDescription)
         })
     }
 
@@ -59,9 +59,9 @@ final class CalendarTableViewController: UITableViewController, EntityTableViewC
         
         switch importer.fetchedResultsController.fetchedObjects?.count {
         case let .some(count) where count > 0:
-            tableView.backgroundView = nil
+            removeBackgroundLabel()
         case let .some(count) where count == 0:
-            setBackgroundLabel(with: "No Calendar Events".localized)
+            setBackgroundLabel(withText: "No Calendar Events".localized)
         default:
             break
         }

--- a/TUM Campus App/Extensions.swift
+++ b/TUM Campus App/Extensions.swift
@@ -127,32 +127,45 @@ extension Session {
     }
 }
 
-extension UITableViewController {
-    func setBackgroundLabel(with text: String) {
-        let noDataLabel = UILabel()
-        noDataLabel.text = text
-        noDataLabel.numberOfLines = 0
-        noDataLabel.font = UIFont.preferredFont(forTextStyle: .title2)
-        noDataLabel.textColor = .systemGray
-        noDataLabel.textAlignment = .center
-        tableView.backgroundView = noDataLabel
+
+protocol __SupportsBackgroundLabel: class {
+    var backgroundView: UIView? { get set }
+}
+
+extension __SupportsBackgroundLabel {
+    func setBackgroundLabel(withText text: String) {
+        let label = UILabel()
+        label.text = text
+        label.numberOfLines = 0
+        label.font = UIFont.preferredFont(forTextStyle: .title2)
+        label.textColor = .systemGray
+        label.textAlignment = .center
+        backgroundView = label
+    }
+    
+    func removeBackgroundLabel() {
+        backgroundView = nil
     }
 }
 
-extension UICollectionView {
-    func setBackgroundLabel(with text: String) {
-        let noDataLabel = UILabel()
-        noDataLabel.text = text
-        noDataLabel.numberOfLines = 0
-        noDataLabel.font = UIFont.preferredFont(forTextStyle: .title2)
-        noDataLabel.textColor = .systemGray
-        noDataLabel.textAlignment = .center
-        backgroundView = noDataLabel
+extension UITableView: __SupportsBackgroundLabel {}
+extension UICollectionView: __SupportsBackgroundLabel {}
+
+extension UITableViewController: __SupportsBackgroundLabel {
+    var backgroundView: UIView? {
+        get { tableView.backgroundView }
+        set { tableView.backgroundView = newValue }
+    }
+}
+extension UICollectionViewController: __SupportsBackgroundLabel {
+    var backgroundView: UIView? {
+        get { collectionView.backgroundView }
+        set { collectionView.backgroundView = newValue }
     }
 }
 
 
- extension KeyPath where Root: NSObject {
+extension KeyPath where Root: NSObject {
     var stringValue: String {
         return NSExpression(forKeyPath: self).keyPath
     }

--- a/TUM Campus App/Grades/GradeTableViewController.swift
+++ b/TUM Campus App/Grades/GradeTableViewController.swift
@@ -52,7 +52,7 @@ final class GradeTableViewController: UITableViewController, EntityTableViewCont
                 self?.reload()
             default: break
             }
-            self?.setBackgroundLabel(with: error.localizedDescription)
+            self?.setBackgroundLabel(withText: error.localizedDescription)
         })
     }
 
@@ -62,9 +62,9 @@ final class GradeTableViewController: UITableViewController, EntityTableViewCont
         setupHeaderView()
         switch importer.fetchedResultsController.fetchedObjects?.count {
         case let .some(count) where count > 0:
-            tableView.backgroundView = nil
+            removeBackgroundLabel()
         case let .some(count) where count == 0:
-            setBackgroundLabel(with: "No Grades".localized)
+            setBackgroundLabel(withText: "No Grades".localized)
         default:
             break
         }

--- a/TUM Campus App/Lectures/LectureTableViewController.swift
+++ b/TUM Campus App/Lectures/LectureTableViewController.swift
@@ -49,7 +49,7 @@ final class LecturesTableViewController: UITableViewController, EntityTableViewC
                 self?.reload()
             default: break
             }
-            self?.setBackgroundLabel(with: error.localizedDescription)
+            self?.setBackgroundLabel(withText: error.localizedDescription)
         })
     }
 
@@ -59,9 +59,9 @@ final class LecturesTableViewController: UITableViewController, EntityTableViewC
 
         switch importer.fetchedResultsController.fetchedObjects?.count {
         case let .some(count) where count > 0:
-            tableView.backgroundView = nil
+            removeBackgroundLabel()
         case let .some(count) where count == 0:
-            setBackgroundLabel(with: "No Lectures".localized)
+            setBackgroundLabel(withText: "No Lectures".localized)
         default:
             break
         }

--- a/TUM Campus App/Room Finder/RoomViewController.swift
+++ b/TUM Campus App/Room Finder/RoomViewController.swift
@@ -60,11 +60,11 @@ final class RoomViewController: UIViewController, UICollectionViewDelegate, UICo
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         switch maps?.count {
         case let .some(count) where count == 0:
-            collectionView.setBackgroundLabel(with: "Missing Map".localized)
+            collectionView.setBackgroundLabel(withText: "Missing Map".localized)
         case let .some(count) where count > 0:
-            collectionView.backgroundView = nil
+            collectionView.removeBackgroundLabel()
         default:
-            collectionView.setBackgroundLabel(with: "Missing Map".localized)
+            collectionView.setBackgroundLabel(withText: "Missing Map".localized)
         }
 
         return maps?.count ?? 0

--- a/TUM Campus App/StudyRoomsGrouped/StudyRoomGroupsTableViewController.swift
+++ b/TUM Campus App/StudyRoomsGrouped/StudyRoomGroupsTableViewController.swift
@@ -62,7 +62,7 @@ final class StudyRoomGroupsTableViewController: UITableViewController, EntityTab
             self?.reload()
         }, error: { [weak self] error in
             self?.tableView.refreshControl?.endRefreshing()
-            self?.setBackgroundLabel(with: error.localizedDescription)
+            self?.setBackgroundLabel(withText: error.localizedDescription)
         })
     }
 
@@ -72,9 +72,9 @@ final class StudyRoomGroupsTableViewController: UITableViewController, EntityTab
 
         switch importer.fetchedResultsController.fetchedObjects?.count {
         case let .some(count) where count > 0:
-            tableView.backgroundView = nil
+            removeBackgroundLabel()
         case let .some(count) where count == 0:
-            setBackgroundLabel(with: "No Study Rooms".localized)
+            setBackgroundLabel(withText: "No Study Rooms".localized)
         default:
             break
         }

--- a/TUM Campus App/TUMSexy/TUMSexyTableViewController.swift
+++ b/TUM Campus App/TUMSexy/TUMSexyTableViewController.swift
@@ -37,7 +37,7 @@ final class TUMSexyTableViewController: UITableViewController, EntityTableViewCo
             self?.reload()
         }, error: { [weak self] error in
             self?.tableView.refreshControl?.endRefreshing()
-            self?.setBackgroundLabel(with: error.localizedDescription)
+            self?.setBackgroundLabel(withText: error.localizedDescription)
         })
     }
 
@@ -47,9 +47,9 @@ final class TUMSexyTableViewController: UITableViewController, EntityTableViewCo
 
         switch importer.fetchedResultsController.fetchedObjects?.count {
         case let .some(count) where count > 0:
-            tableView.backgroundView = nil
+            removeBackgroundLabel()
         case let .some(count) where count == 0:
-            setBackgroundLabel(with: "No Links".localized)
+            setBackgroundLabel(withText: "No Links".localized)
         default:
             break
         }

--- a/TUM Campus App/Tuition/TuitionTableViewController.swift
+++ b/TUM Campus App/Tuition/TuitionTableViewController.swift
@@ -50,7 +50,7 @@ final class TuitionTableViewController: UITableViewController, EntityTableViewCo
                 self?.reload()
             default: break
             }
-            self?.setBackgroundLabel(with: error.localizedDescription)
+            self?.setBackgroundLabel(withText: error.localizedDescription)
         })
     }
 
@@ -60,9 +60,9 @@ final class TuitionTableViewController: UITableViewController, EntityTableViewCo
 
         switch importer.fetchedResultsController.fetchedObjects?.count {
         case let .some(count) where count > 0:
-            tableView.backgroundView = nil
+            removeBackgroundLabel()
         case let .some(count) where count == 0:
-            setBackgroundLabel(with: "No Tuition Fees".localized)
+            setBackgroundLabel(withText: "No Tuition Fees".localized)
         default:
             break
         }

--- a/TUM Campus App/de.lproj/Localizable.strings
+++ b/TUM Campus App/de.lproj/Localizable.strings
@@ -40,4 +40,7 @@
 "Useful Links" = "Nützliche Links";
 "No Links" = "Keine Links";
 "Cafeteria Map" = "Mensa Landkarte";
+"Search Rooms" = "Räume suchen";
+"Room Finder" = "Room Finder";
+"Unable to find room" = "Raum '%@' konnte nicht gefunden werden";
 "No Menu" = "Kein Menü";


### PR DESCRIPTION
- Show a label with an error message if a room couldn't be found. This seems better than just displaying an empty table
- Added an explicit check if a room finder API request was cancelled, since for some reason the completion handler would still get invoked even after calling `sessionManager.cancelAllRequests()`
- Added some missing localisations to the german string file