### PR TITLE
consistently name cafeterias tab bar item "Cafeterias"

### DIFF
--- a/TUM Campus App/Base.lproj/Main.storyboard
+++ b/TUM Campus App/Base.lproj/Main.storyboard
@@ -97,11 +97,11 @@
             </objects>
             <point key="canvasLocation" x="-1721" y="715"/>
         </scene>
-        <!--Cafeteria-->
+        <!--Cafeterias-->
         <scene sceneID="vhB-J7-tOY">
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xfx-5j-asa" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Cafeteria" image="house" catalog="system" id="RRw-AB-qv3"/>
+                    <tabBarItem key="tabBarItem" title="Cafeterias" image="house" catalog="system" id="RRw-AB-qv3"/>
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="IVM-Bt-bKi">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>

--- a/TUM Campus AppUITests/TUM_Campus_AppUITests.swift
+++ b/TUM Campus AppUITests/TUM_Campus_AppUITests.swift
@@ -56,7 +56,7 @@ class TUM_Campus_AppUITests: XCTestCase {
 
     func testCafeteria() {
         let app = XCUIApplication()
-        app.tabBars["Tab Bar"].buttons["Cafeteria"].tap()
+        app.tabBars["Tab Bar"].buttons["Cafeterias"].tap()
         app.alerts["Allow “Campus App” to use your location?"].scrollViews.otherElements.buttons["Allow While Using App"].tap()
         app.collectionViews/*@START_MENU_TOKEN@*/.staticTexts["Mensa Arcisstraße"]/*[[".cells.staticTexts[\"Mensa Arcisstraße\"]",".staticTexts[\"Mensa Arcisstraße\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
         app.navigationBars["Mensa Arcisstraße"].buttons["Cafeterias"].tap()


### PR DESCRIPTION
Problem: when launching the app, the 3rd tab bar item is labeled "Cafeteria", and selecting it causes the name to change to "Cafeterias".

Fix: always label it "Cafeterias"