### PR TITLE
Set label count manually to fix label alignment in grade chart

### DIFF
--- a/TUM Campus App/Grades/BarChartCollectionViewCell.swift
+++ b/TUM Campus App/Grades/BarChartCollectionViewCell.swift
@@ -22,6 +22,7 @@ final class GradeChartCollectionViewCell: UICollectionViewCell {
         xAxis.labelFont = .systemFont(ofSize: 10)
         xAxis.drawAxisLineEnabled = true
         xAxis.drawGridLinesEnabled = false
+        xAxis.labelCount = chartViewModel.gradeStrings.count
         xAxis.valueFormatter = IndexAxisValueFormatter(values: chartViewModel.gradeStrings)
 
         let leftAxis = barChartView.leftAxis


### PR DESCRIPTION
### Issue
Closes #346. This is achieved by setting the number of labels manually.

### Screenshots
Before the fix:
![96545750-42894f00-12a9-11eb-9f03-5c1a5cdea1f7](https://user-images.githubusercontent.com/26229617/97030056-8ce72600-155e-11eb-8169-d2cf36507188.jpeg)

After the fix:
![IMG_19F704D7CF99-1](https://user-images.githubusercontent.com/26229617/97029969-70e38480-155e-11eb-9cc7-34b73d234220.jpeg)

