### PR TITLE
Parse tution fees with locale

### DIFF
--- a/TUM Campus App/Tuition/Tuition.swift
+++ b/TUM Campus App/Tuition/Tuition.swift
@@ -40,15 +40,16 @@ import CoreData
         let semester = try container.decode(String.self, forKey: .semester)
         let semesterID = try container.decode(String.self, forKey: .semesterID)
         let amountString = try container.decode(String.self, forKey: .amount)
-        guard let amount = Decimal(string: amountString) else {
-            throw DecodingError.typeMismatch(Int64.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Value for amount could not be converted to Int64"))
+        let amount = NSDecimalNumber(string: amountString, locale: Locale.init(identifier: "de"))
+        if amount == NSDecimalNumber.notANumber {
+            throw DecodingError.typeMismatch(NSDecimalNumber.self, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Value for amount could not be converted to Decimal."))
         }
         
         self.init(entity: Tuition.entity(), insertInto: context)
         self.deadline = deadline
         self.semester = semester
         self.semesterID = semesterID
-        self.amount = NSDecimalNumber(decimal: amount)
+        self.amount = amount
     }
     
     @nonobjc public class func fetchRequest() -> NSFetchRequest<Tuition> {


### PR DESCRIPTION
fixes #353

### Screenshots
before | after
---|---
![Simulator Screen Shot - iPhone 11 - 2021-01-31 at 10 17 32](https://user-images.githubusercontent.com/44805696/106379635-924ddb00-63ad-11eb-85b1-e110dbda134d.png) | ![Simulator Screen Shot - iPhone 11 - 2021-01-31 at 09 59 47](https://user-images.githubusercontent.com/44805696/106379592-49962200-63ad-11eb-939f-ea52fe223625.png)

If we drop that error handling it would just display NaN in case of parsing errors. That might be fine as well because students could then at least see the deadline instead of just an error message. 