### PR TITLE
created iso8601 calendar for determining weekOfYear

### DIFF
--- a/TUM Campus App/Extensions/Extensions.swift
+++ b/TUM Campus App/Extensions/Extensions.swift
@@ -187,8 +187,10 @@ extension CLLocationCoordinate2D  {
 
 extension Date {
     var calendar: Calendar { Calendar(identifier: Calendar.current.identifier) }
-    var weekOfYear: Int { calendar.component(.weekOfYear, from: self) }
     var weekOfMonth: Int { calendar.component(.weekOfMonth, from: self) }
+    
+    var isoCalendar: Calendar { Calendar(identifier: .iso8601) }
+    var weekOfYear: Int { isoCalendar.component(.weekOfYear, from: self) }
 
     var year: Int {
         get {


### PR DESCRIPTION
### Issue
If the user looks at the Mensa menu only the upcoming week will be displayed right now. This is caused by different calendar standards used in Campus iOS App and the Eat API resulting in a different weekOfYear than expected by the API. See https://en.wikipedia.org/wiki/Week#Other_week_numbering_systems for further information.

Calculating weekOfYear in the ISO8601 Calendar fixes this issues.
