### PR TITLE
Fix broken mensa tab

### DIFF
--- a/MensaMenuWidget/MensaMenuWidget.swift
+++ b/MensaMenuWidget/MensaMenuWidget.swift
@@ -96,11 +96,11 @@ struct MensaMenuWidgetEntryView : View {
                     .padding(.bottom, 5)
                 ForEach(getDishes(sideDishes: false).prefix(family == .systemLarge ? 8 : 7), id: \.self) { dish in
                     HStack {
-                        Text(foodEmojiProvider(ingredients: dish.labels, dishType: dish.dishType)).font(.system(size: 13))
+                        Text(foodEmojiProvider(labels: dish.labels, dishType: dish.dishType)).font(.system(size: 13))
                         Text(dish.name)
                             .lineLimit(1)
                             .font(.system(size: 14, weight: .semibold))
-                        Text(ingredientsToString(ingredients: dish.labels))
+                        Text(labelsToString(labels: dish.labels))
                             .font(.system(size: 10, weight: .semibold))
                             .foregroundColor(Color.secondary)
                             .lineLimit(1)
@@ -132,7 +132,7 @@ struct MensaMenuWidgetEntryView : View {
                                 Text(dish.name)
                                     .lineLimit(1)
                                     .font(.system(size: 14, weight: .semibold))
-                                Text(ingredientsToString(ingredients: dish.labels))
+                                Text(labelsToString(labels: dish.labels))
                                     .font(.system(size: 10, weight: .semibold))
                                     .foregroundColor(Color.secondary)
                                     .lineLimit(1)
@@ -158,36 +158,43 @@ struct MensaMenuWidgetEntryView : View {
         entry.menu?.dishes.filter({ sideDishes ? $0.dishType == "Beilagen" : $0.dishType != "Beilagen"}) ?? []
     }
     
-    func ingredientsToString(ingredients: [String]) -> String {
-        let string = ingredients.joined(separator:",")
+    func labelsToString(labels: [String]) -> String {
+        let labelLookup = MensaService.shared.getLabels()
+        var shortenedLabels: [String] = []
+        
+        for label in labels{
+            if let labelObject = labelLookup[label] {
+                shortenedLabels.append(labelObject.abbreviation)
+            }else{
+                shortenedLabels.append(label)
+            }
+        }
+        
+        let string = shortenedLabels.joined(separator:",")
         if string != "" {
             return "(" + string + ")"
         }
         return ""
     }
     
-    func foodEmojiProvider(ingredients: [String], dishType: String) -> String {
-        if ingredients.contains("f") {
-            return "🥕"
-        } else if ingredients.contains("v") {
-            return "🫑"
-        } else if ingredients.contains("S") {
-            return "🐷"
-        } else if ingredients.contains("R") {
-            return "🥩"
-        } else if ingredients.contains("W") {
-            return "🦌"
-        } else if ingredients.contains("L") {
-            return "🐑"
-        } else if ingredients.contains("Fi") {
-            return "🐟"
-        } else if !ingredients.contains("Ei") && !ingredients.contains("Mi") && dishType != "Fleisch" && dishType != "Fisch" && dishType != "Grill" { //vegan (without v tag)
-            return "🫑"
-        } else if !ingredients.contains("14") && dishType != "Fleisch" && dishType != "Fisch" && dishType != "Grill" { //vegertarian (without f tag)
-            return "🥕"
-        } else {
-            return "❓"
+    func foodEmojiProvider(labels: [String], dishType: String) -> String {
+        let emojiLabels = ["VEGAN", "VEGETARIAN", "PORK", "BEEF", "WILD_MEAT", "LAMB", "DISH"]
+        for label in emojiLabels{
+            if labels.contains(label){
+                let labelLookup = MensaService.shared.getLabels()
+                if let labelObject = labelLookup[label]{
+                    return labelObject.abbreviation
+                }
+            }
         }
+        
+        if !labels.contains("CHICKEN_EGGS") && !labels.contains("MILK") && dishType != "Fleisch" && dishType != "Fisch" && dishType != "Grill" { //vegan (without v tag)
+            return "🫑"
+        } else if !labels.contains("GELATIN") && dishType != "Fleisch" && dishType != "Fisch" && dishType != "Grill" { //vegertarian (without f tag)
+            return "🥕"
+        }
+        
+        return "❓"
     }
 }
 

--- a/MensaMenuWidget/MensaMenuWidget.swift
+++ b/MensaMenuWidget/MensaMenuWidget.swift
@@ -96,11 +96,11 @@ struct MensaMenuWidgetEntryView : View {
                     .padding(.bottom, 5)
                 ForEach(getDishes(sideDishes: false).prefix(family == .systemLarge ? 8 : 7), id: \.self) { dish in
                     HStack {
-                        Text(foodEmojiProvider(ingredients: dish.ingredients, dishType: dish.dishType)).font(.system(size: 13))
+                        Text(foodEmojiProvider(ingredients: dish.labels, dishType: dish.dishType)).font(.system(size: 13))
                         Text(dish.name)
                             .lineLimit(1)
                             .font(.system(size: 14, weight: .semibold))
-                        Text(ingredientsToString(ingredients: dish.ingredients))
+                        Text(ingredientsToString(ingredients: dish.labels))
                             .font(.system(size: 10, weight: .semibold))
                             .foregroundColor(Color.secondary)
                             .lineLimit(1)
@@ -132,7 +132,7 @@ struct MensaMenuWidgetEntryView : View {
                                 Text(dish.name)
                                     .lineLimit(1)
                                     .font(.system(size: 14, weight: .semibold))
-                                Text(ingredientsToString(ingredients: dish.ingredients))
+                                Text(ingredientsToString(ingredients: dish.labels))
                                     .font(.system(size: 10, weight: .semibold))
                                     .foregroundColor(Color.secondary)
                                     .lineLimit(1)

--- a/MensaMenuWidget/MensaService.swift
+++ b/MensaMenuWidget/MensaService.swift
@@ -12,6 +12,7 @@ import Alamofire
 final class MensaService {
     static let shared = MensaService()
     private var menu: Menu?
+    private var labels: [String:Label] = [:]
     
     public func getMensaMenu(mensaApiKey: String) -> Menu? {
         let decoder = JSONDecoder()
@@ -28,5 +29,16 @@ final class MensaService {
             })
         }
         return menu
+    }
+    
+    public func getLabels() -> [String:Label]{
+        AF.request(EatAPI.labels).responseDecodable(of: [Label].self) { (response) in
+            let labels = response.value ?? []
+            for label in labels{
+                self.labels[label.name] = label
+            }
+        }
+        
+        return self.labels
     }
 }

--- a/TUM Campus App.xcodeproj/project.pbxproj
+++ b/TUM Campus App.xcodeproj/project.pbxproj
@@ -158,6 +158,8 @@
 		239D3CFD2766255B00D1E4D8 /* CafeteriaLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */; };
 		239D3CFE2766255B00D1E4D8 /* CafeteriaLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */; };
 		239F5E6C275AB909002FDD6A /* MockMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239F5E6B275AB908002FDD6A /* MockMenu.swift */; };
+		254DA93E278F1DB100FC9608 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA93D278F1DB100FC9608 /* Label.swift */; };
+		254DA93F278F1ECA00FC9608 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA93D278F1DB100FC9608 /* Label.swift */; };
 		41FBF9FB270CC26C009F329A /* CafeteriaMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -346,6 +348,7 @@
 		239D3CF92766211E00D1E4D8 /* MensaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MensaService.swift; sourceTree = "<group>"; };
 		239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaLocation.swift; sourceTree = "<group>"; };
 		239F5E6B275AB908002FDD6A /* MockMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMenu.swift; sourceTree = "<group>"; };
+		254DA93D278F1DB100FC9608 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
 		41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaMapViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -694,6 +697,7 @@
 				224F37C22460EA5A00BEDA71 /* MealPlan.swift */,
 				22F9629D246177D9004BF215 /* Menu.swift */,
 				22F9629B2460ED03004BF215 /* Dish.swift */,
+				254DA93D278F1DB100FC9608 /* Label.swift */,
 				41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */,
 				224CB3AA222C48DB0002945A /* CafeteriaCollectionViewCell.swift */,
 				22F9629F246193C3004BF215 /* MealPlanTableViewController.swift */,
@@ -1061,6 +1065,7 @@
 				229C549724954BF700EFD5A2 /* Movie.swift in Sources */,
 				22AE458E247B214200CE5B29 /* MapCell.swift in Sources */,
 				2294545D22198B25008E41B7 /* AuthenticationHandler.swift in Sources */,
+				254DA93E278F1DB100FC9608 /* Label.swift in Sources */,
 				224F37C32460EA5A00BEDA71 /* MealPlan.swift in Sources */,
 				22BC2CE021DE35FD00FF7C00 /* CampusTabBarController.swift in Sources */,
 				2255F68B24A3EF2E00AD6E2C /* SectionBackgroundDecorationView.swift in Sources */,
@@ -1124,6 +1129,7 @@
 				239D3CF12766188B00D1E4D8 /* Date+Extensions.swift in Sources */,
 				233C51EA2759148400477D89 /* EatAPI.swift in Sources */,
 				239D3CFB2766211E00D1E4D8 /* MensaService.swift in Sources */,
+				254DA93F278F1ECA00FC9608 /* Label.swift in Sources */,
 				239D3CFE2766255B00D1E4D8 /* CafeteriaLocation.swift in Sources */,
 				233C51E22759104800477D89 /* Dish.swift in Sources */,
 				233C51DF27590FD000477D89 /* Menu.swift in Sources */,

--- a/TUM Campus App.xcodeproj/project.pbxproj
+++ b/TUM Campus App.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		239F5E6C275AB909002FDD6A /* MockMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239F5E6B275AB908002FDD6A /* MockMenu.swift */; };
 		254DA93E278F1DB100FC9608 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA93D278F1DB100FC9608 /* Label.swift */; };
 		254DA93F278F1ECA00FC9608 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA93D278F1DB100FC9608 /* Label.swift */; };
+		254DA941278F33C400FC9608 /* MensaEnumService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA940278F33C400FC9608 /* MensaEnumService.swift */; };
 		41FBF9FB270CC26C009F329A /* CafeteriaMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -349,6 +350,7 @@
 		239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaLocation.swift; sourceTree = "<group>"; };
 		239F5E6B275AB908002FDD6A /* MockMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMenu.swift; sourceTree = "<group>"; };
 		254DA93D278F1DB100FC9608 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
+		254DA940278F33C400FC9608 /* MensaEnumService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MensaEnumService.swift; sourceTree = "<group>"; };
 		41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaMapViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -698,6 +700,7 @@
 				22F9629D246177D9004BF215 /* Menu.swift */,
 				22F9629B2460ED03004BF215 /* Dish.swift */,
 				254DA93D278F1DB100FC9608 /* Label.swift */,
+				254DA940278F33C400FC9608 /* MensaEnumService.swift */,
 				41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */,
 				224CB3AA222C48DB0002945A /* CafeteriaCollectionViewCell.swift */,
 				22F9629F246193C3004BF215 /* MealPlanTableViewController.swift */,
@@ -1091,6 +1094,7 @@
 				224CB36B2226B7980002945A /* APIResponse.swift in Sources */,
 				22DE82B824AE823D001EFAB4 /* LectureSearchViewController.swift in Sources */,
 				227395B724B4AC1F0024CD21 /* MovieDetailViewModel.swift in Sources */,
+				254DA941278F33C400FC9608 /* MensaEnumService.swift in Sources */,
 				224CB3672225A7F00002945A /* StudyRoomAttribute.swift in Sources */,
 				227395B524B4ABF20024CD21 /* MovieDetailCell.swift in Sources */,
 				222470D824632F8200B196B6 /* MenuCollectionViewController.swift in Sources */,

--- a/TUM Campus App.xcodeproj/project.pbxproj
+++ b/TUM Campus App.xcodeproj/project.pbxproj
@@ -158,6 +158,7 @@
 		239D3CFD2766255B00D1E4D8 /* CafeteriaLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */; };
 		239D3CFE2766255B00D1E4D8 /* CafeteriaLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */; };
 		239F5E6C275AB909002FDD6A /* MockMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 239F5E6B275AB908002FDD6A /* MockMenu.swift */; };
+		253ED1B7279EBEF6005255EB /* MenuLabelsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 253ED1B6279EBEF6005255EB /* MenuLabelsTableViewController.swift */; };
 		254DA93E278F1DB100FC9608 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA93D278F1DB100FC9608 /* Label.swift */; };
 		254DA93F278F1ECA00FC9608 /* Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA93D278F1DB100FC9608 /* Label.swift */; };
 		254DA941278F33C400FC9608 /* MensaEnumService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 254DA940278F33C400FC9608 /* MensaEnumService.swift */; };
@@ -349,6 +350,7 @@
 		239D3CF92766211E00D1E4D8 /* MensaService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MensaService.swift; sourceTree = "<group>"; };
 		239D3CFC2766255B00D1E4D8 /* CafeteriaLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaLocation.swift; sourceTree = "<group>"; };
 		239F5E6B275AB908002FDD6A /* MockMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockMenu.swift; sourceTree = "<group>"; };
+		253ED1B6279EBEF6005255EB /* MenuLabelsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuLabelsTableViewController.swift; sourceTree = "<group>"; };
 		254DA93D278F1DB100FC9608 /* Label.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Label.swift; sourceTree = "<group>"; };
 		254DA940278F33C400FC9608 /* MensaEnumService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MensaEnumService.swift; sourceTree = "<group>"; };
 		41FBF9FA270CC26C009F329A /* CafeteriaMapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeteriaMapViewController.swift; sourceTree = "<group>"; };
@@ -707,6 +709,7 @@
 				222470D724632F8200B196B6 /* MenuCollectionViewController.swift */,
 				222470DB2463507700B196B6 /* MenuSectionHeader.swift */,
 				222470D9246338F900B196B6 /* MenuCollectionViewCell.swift */,
+				253ED1B6279EBEF6005255EB /* MenuLabelsTableViewController.swift */,
 			);
 			path = Cafeteria;
 			sourceTree = "<group>";
@@ -1036,6 +1039,7 @@
 				239D3CF327661BED00D1E4D8 /* String+Extensions.swift in Sources */,
 				224BBF0A24BFAD280055DD4C /* AvatarNavigationBar.swift in Sources */,
 				2277E91821D93C3300D7FF3F /* TUM_Campus_App.xcdatamodeld in Sources */,
+				253ED1B7279EBEF6005255EB /* MenuLabelsTableViewController.swift in Sources */,
 				22DE82B624AE8214001EFAB4 /* PersonSearchViewController.swift in Sources */,
 				225AD73F2479CD14001A969E /* CalendarEventCell.swift in Sources */,
 				224CB389222AA6620002945A /* NewsSource.swift in Sources */,

--- a/TUM Campus App/API/EatAPI.swift
+++ b/TUM Campus App/API/EatAPI.swift
@@ -11,6 +11,8 @@ import Foundation
 
 enum EatAPI: URLRequestConvertible {
     case canteens
+    case languages
+    case labels
     case all
     case all_ref
     case menu(location: String, year: Int = Date().year, week: Int = Date().weekOfYear)
@@ -27,7 +29,9 @@ enum EatAPI: URLRequestConvertible {
 
     var path: String {
         switch self {
-        case .canteens:                         return "canteens.json"
+        case .canteens:                         return "enums/canteens.json"
+        case .languages:                        return "enums/languages.json"
+        case .labels:                           return "enums/labels.json"
         case .all:                              return "all.json"
         case .all_ref:                          return "all_ref.json"
         case let .menu(location, year, week):   return "\(location)/\(year)/\(String(format: "%02d", week)).json"

--- a/TUM Campus App/API/EatAPI.swift
+++ b/TUM Campus App/API/EatAPI.swift
@@ -30,7 +30,7 @@ enum EatAPI: URLRequestConvertible {
         case .canteens:                         return "canteens.json"
         case .all:                              return "all.json"
         case .all_ref:                          return "all_ref.json"
-        case let .menu(location, year, week):   return "\(location)/\(year)/\(week).json"
+        case let .menu(location, year, week):   return "\(location)/\(year)/\(String(format: "%02d", week)).json"
         }
     }
 

--- a/TUM Campus App/Base.lproj/Main.storyboard
+++ b/TUM Campus App/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pHE-Lh-fSC">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pHE-Lh-fSC">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -457,7 +457,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <view key="tableFooterView" contentMode="scaleToFill" id="T0A-pD-y4X">
-                            <rect key="frame" x="0.0" y="814.5" width="375" height="54"/>
+                            <rect key="frame" x="0.0" y="815" width="375" height="54"/>
                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             <subviews>
                                 <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Version 1.0.0" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6cx-bG-yLI">
@@ -481,11 +481,11 @@
                                         <rect key="frame" x="0.0" y="35" width="375" height="95"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ecW-VA-gz8" id="2Mx-yd-5Dx">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="95"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="95"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="4Ir-WK-wVh">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="79"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="79"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.crop.circle.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="VDP-b4-Fam">
                                                             <rect key="frame" x="0.0" y="2" width="76" height="75"/>
@@ -496,16 +496,16 @@
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Fux-ag-YuK">
-                                                            <rect key="frame" x="84" y="22" width="241.5" height="35"/>
+                                                            <rect key="frame" x="84" y="22" width="242.5" height="35"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A9z-mM-YNj">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="241.5" height="20.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="242.5" height="20.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TUM ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="34H-Ri-CR8">
-                                                                    <rect key="frame" x="0.0" y="20.5" width="241.5" height="14.5"/>
+                                                                    <rect key="frame" x="0.0" y="20.5" width="242.5" height="14.5"/>
                                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                                     <color key="textColor" systemColor="secondaryLabelColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -532,11 +532,11 @@
                                         <rect key="frame" x="0.0" y="179.5" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eug-aw-P6k" id="vld-TA-0Ib">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="45.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="QiN-TV-7G7">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="29.5"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="29.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Tuition" translatesAutoresizingMaskIntoConstraints="NO" id="pGK-23-unC">
                                                             <rect key="frame" x="0.0" y="0.5" width="29" height="29"/>
@@ -545,13 +545,13 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Tuition" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vCY-b0-Qk4">
-                                                            <rect key="frame" x="37" y="6.5" width="239" height="17"/>
+                                                            <rect key="frame" x="37" y="6.5" width="240" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3lu-Pd-Knu">
-                                                            <rect key="frame" x="284" y="4.5" width="41.5" height="20.5"/>
+                                                            <rect key="frame" x="285" y="4.5" width="41.5" height="20.5"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -573,11 +573,11 @@
                                         <rect key="frame" x="0.0" y="225" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HFr-3N-IHO" id="wDS-En-i1E">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="45.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="mm7-NY-D5H">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="29.5"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="29.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Search" translatesAutoresizingMaskIntoConstraints="NO" id="KhM-c0-ABa">
                                                             <rect key="frame" x="0.0" y="0.5" width="29" height="29"/>
@@ -586,7 +586,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Person Search" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hkv-lo-cVB">
-                                                            <rect key="frame" x="37" y="6.5" width="288.5" height="17"/>
+                                                            <rect key="frame" x="37" y="6.5" width="289.5" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -611,11 +611,11 @@
                                         <rect key="frame" x="0.0" y="270.5" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8M4-oN-9Tr" id="k5Q-Xz-QR3">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="45.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="0Hp-N4-y41">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="29.5"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="29.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Lectures" translatesAutoresizingMaskIntoConstraints="NO" id="lL1-AW-lwx">
                                                             <rect key="frame" x="0.0" y="0.5" width="29" height="29"/>
@@ -624,7 +624,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Lecture Search" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tes-Zq-3pG">
-                                                            <rect key="frame" x="37" y="6.5" width="288.5" height="17"/>
+                                                            <rect key="frame" x="37" y="6.5" width="289.5" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -653,11 +653,11 @@
                                         <rect key="frame" x="0.0" y="365.5" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="jOZ-tr-ALX" id="4fm-yK-N6o">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="45.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AdS-cT-D6h">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="29.5"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="29.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Tum.sexy" translatesAutoresizingMaskIntoConstraints="NO" id="C92-JS-dee">
                                                             <rect key="frame" x="0.0" y="0.0" width="29.5" height="29.5"/>
@@ -666,7 +666,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="TUM.sexy" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vCZ-mu-j3F">
-                                                            <rect key="frame" x="37.5" y="0.0" width="288" height="29.5"/>
+                                                            <rect key="frame" x="37.5" y="0.0" width="289" height="29.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -688,11 +688,11 @@
                                         <rect key="frame" x="0.0" y="411" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UUR-h7-ZXf" id="sSf-FV-quQ">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="45.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="OvY-nD-CGS">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="29.5"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="29.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RoomFinder" translatesAutoresizingMaskIntoConstraints="NO" id="7Ts-pv-h0g">
                                                             <rect key="frame" x="0.0" y="0.0" width="29.5" height="29.5"/>
@@ -701,7 +701,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Room Finder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eX3-y7-l7q">
-                                                            <rect key="frame" x="37.5" y="0.0" width="288" height="29.5"/>
+                                                            <rect key="frame" x="37.5" y="0.0" width="289" height="29.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -726,11 +726,11 @@
                                         <rect key="frame" x="0.0" y="456.5" width="375" height="45.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="FhU-eu-h9G" id="FEW-74-F9M">
-                                            <rect key="frame" x="0.0" y="0.0" width="349.5" height="45.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="45.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="RgJ-Jd-qLe">
-                                                    <rect key="frame" x="16" y="8" width="325.5" height="29.5"/>
+                                                    <rect key="frame" x="16" y="8" width="326.5" height="29.5"/>
                                                     <subviews>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="News" translatesAutoresizingMaskIntoConstraints="NO" id="w6E-Xv-CYt">
                                                             <rect key="frame" x="0.0" y="0.0" width="29.5" height="29.5"/>
@@ -739,7 +739,7 @@
                                                             </constraints>
                                                         </imageView>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="News" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="150-f7-yD0">
-                                                            <rect key="frame" x="37.5" y="0.0" width="288" height="29.5"/>
+                                                            <rect key="frame" x="37.5" y="0.0" width="289" height="29.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -977,21 +977,21 @@
                                 <rect key="frame" x="0.0" y="44.5" width="375" height="72"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="F7t-Pu-RaQ" id="GIz-dH-IFj">
-                                    <rect key="frame" x="0.0" y="0.0" width="349.5" height="72"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="350.5" height="72"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="WR3-cN-xGW">
-                                            <rect key="frame" x="16" y="16" width="317.5" height="40"/>
+                                            <rect key="frame" x="16" y="16" width="318.5" height="40"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Building" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="IXk-4p-ZRm">
-                                                    <rect key="frame" x="0.0" y="0.0" width="226.5" height="40"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="227.5" height="40"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="nr free rooms" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fcw-L0-8EV" userLabel="numberLabel">
-                                                    <rect key="frame" x="230.5" y="0.0" width="87" height="40"/>
+                                                    <rect key="frame" x="231.5" y="0.0" width="87" height="40"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <color key="textColor" name="tumBlue"/>
                                                     <nil key="highlightedColor"/>
@@ -1050,22 +1050,22 @@
                                 <rect key="frame" x="0.0" y="44.5" width="375" height="83"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qx9-uJ-NGG" id="Cgd-09-mvT">
-                                    <rect key="frame" x="0.0" y="0.0" width="349.5" height="83"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="350.5" height="83"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="L7q-Ja-yGG">
-                                            <rect key="frame" x="16" y="11" width="325.5" height="61"/>
+                                            <rect key="frame" x="16" y="11" width="326.5" height="61"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" verticalHuggingPriority="248" axis="vertical" distribution="fillProportionally" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="20q-h8-125">
-                                                    <rect key="frame" x="0.0" y="0.0" width="280" height="61"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="281" height="61"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Raumname" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xu0-o0-BRm">
-                                                            <rect key="frame" x="0.0" y="0.0" width="280" height="27.5"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="281" height="27.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="249" text="Raumnummer" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bBG-QR-e9b">
-                                                            <rect key="frame" x="0.0" y="31.5" width="280" height="29.5"/>
+                                                            <rect key="frame" x="0.0" y="31.5" width="281" height="29.5"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                             <color key="textColor" systemColor="secondaryLabelColor"/>
                                                             <nil key="highlightedColor"/>
@@ -1073,7 +1073,7 @@
                                                     </subviews>
                                                 </stackView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="252" text="Status" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A5l-j6-Djd">
-                                                    <rect key="frame" x="284" y="0.0" width="41.5" height="61"/>
+                                                    <rect key="frame" x="285" y="0.0" width="41.5" height="61"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1165,20 +1165,20 @@
                                 <rect key="frame" x="0.0" y="44.5" width="375" height="99"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ViG-mV-htz" id="EGh-H5-m4Q">
-                                    <rect key="frame" x="0.0" y="0.0" width="349.5" height="99"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="350.5" height="99"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="HLf-jy-6oF">
-                                            <rect key="frame" x="16" y="11" width="325.5" height="77"/>
+                                            <rect key="frame" x="16" y="11" width="326.5" height="77"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="info" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HnF-ip-IAl">
-                                                    <rect key="frame" x="0.0" y="0.0" width="325.5" height="56"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="326.5" height="56"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="AF4-lW-yeh">
-                                                    <rect key="frame" x="0.0" y="60" width="325.5" height="17"/>
+                                                    <rect key="frame" x="0.0" y="60" width="326.5" height="17"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="room_code" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="A0U-Rx-CNQ">
                                                             <rect key="frame" x="0.0" y="0.0" width="73" height="17"/>
@@ -1187,7 +1187,7 @@
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="purpose" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xDK-2x-Kpy">
-                                                            <rect key="frame" x="81" y="0.0" width="244.5" height="17"/>
+                                                            <rect key="frame" x="81" y="0.0" width="245.5" height="17"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                             <color key="textColor" systemColor="tertiaryLabelColor"/>
                                                             <nil key="highlightedColor"/>
@@ -1386,7 +1386,7 @@
                                 <rect key="frame" x="0.0" y="44.5" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xtY-qt-bne" id="HT7-fT-YFc">
-                                    <rect key="frame" x="0.0" y="0.0" width="349.5" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="lNW-Sf-KWs">
@@ -1397,7 +1397,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ADU-50-nPQ">
-                                            <rect key="frame" x="306.5" y="15" width="35" height="16"/>
+                                            <rect key="frame" x="307.5" y="15" width="35" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCallout"/>
                                             <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -2070,7 +2070,7 @@
                                 <rect key="frame" x="0.0" y="44.5" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="tQ5-PB-qHH" id="jEM-Qp-eHf">
-                                    <rect key="frame" x="0.0" y="0.0" width="349.5" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="350.5" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableViewCellContentView>
                             </tableViewCell>
@@ -2180,6 +2180,47 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fIB-Oc-feL" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="2816.8000000000002" y="-682.3088455772114"/>
+        </scene>
+        <!--Menu Labels Table View Controller-->
+        <scene sceneID="Fr5-pb-6lq">
+            <objects>
+                <viewController storyboardIdentifier="MenuLabelsTableViewController" id="zHi-Ag-YVB" customClass="MenuLabelsTableViewController" customModule="TUMCampusApp" customModuleProvider="target" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" id="wfa-PS-enT">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="LabelCell" textLabel="I0T-z6-Wer" detailTextLabel="oKh-vd-YZ0" style="IBUITableViewCellStyleValue1" id="fRf-hg-Ndh">
+                                <rect key="frame" x="0.0" y="44.5" width="375" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fRf-hg-Ndh" id="b8Y-fP-WLI">
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="I0T-z6-Wer">
+                                            <rect key="frame" x="16" y="15" width="25" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="oKh-vd-YZ0">
+                                            <rect key="frame" x="326" y="15" width="33" height="14.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="0.0"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                    </subviews>
+                                </tableViewCellContentView>
+                            </tableViewCell>
+                        </prototypes>
+                        <sections/>
+                    </tableView>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="klk-ci-CH4" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3660" y="-682.3088455772114"/>
         </scene>
         <!--Grade Collection View Controller-->
         <scene sceneID="3qt-y1-33k">
@@ -2509,7 +2550,7 @@
     </scenes>
     <designables>
         <designable name="YE4-j8-svX">
-            <size key="intrinsicContentSize" width="20" height="26"/>
+            <size key="intrinsicContentSize" width="35" height="34"/>
         </designable>
     </designables>
     <inferredMetricsTieBreakers>

--- a/TUM Campus App/Cafeteria/Dish.swift
+++ b/TUM Campus App/Cafeteria/Dish.swift
@@ -45,11 +45,8 @@ struct Dish: Decodable, Hashable {
                 "unit": "100g"
             }
         },
-        "ingredients": [
-            "2",
-            "Gl",
-            "GlW",
-            "Kn"
+        "labels": [
+            "VEGETARIAN"
         ],
         "dish_type": "Pasta"
     },
@@ -57,71 +54,13 @@ struct Dish: Decodable, Hashable {
 
     let name: String
     let prices: [String: Price?]
-    let ingredients: [String]
+    let labels: [String]
     let dishType: String
-
-    var namedIngredients: [String] {
-        ingredients.map { (ingredientsLookup[$0] ?? $0) }
-    }
-
-    private var ingredientsLookup = [
-        "GQB" : "GQB",
-        "MSC" : "MSC",
-
-        "1" : "dyed",
-        "2" : "preservative",
-        "3" : "antioxidant",
-        "4" : "flavor enhancers",
-        "5" : "sulphured",
-        "6" : "blackened (olive)",
-        "7" : "waxed",
-        "8" : "phosphates",
-        "9" : "sweeteners",
-        "10" : "contains a source of phenylalanine",
-        "11" : "sugar and sweeteners",
-        "13" : "cocoa-containing grease",
-        "14" : "gelatin",
-        "99" : "alcohol",
-
-        "f" : "meatless dish",
-        "v" : "vegan dish",
-        "S" : "pork",
-        "R" : "beef",
-        "K" : "veal",
-        "G" : "poultry", // mediziner mensa
-        "W" : "wild meat", // mediziner mensa
-        "L" : "lamb", // mediziner mensa
-        "Kn" : "garlic",
-        "Ei" : "chicken egg",
-        "En" : "peanut",
-        "Fi" : "fish",
-        "Gl" : "gluten-containing cereals",
-        "GlW" : "wheat",
-        "GlR" : "rye",
-        "GlG" : "barley",
-        "GlH" : "oats",
-        "GlD" : "spelt",
-        "Kr" : "crustaceans",
-        "Lu" : "lupines",
-        "Mi" : "milk and lactose",
-        "Sc" : "shell fruits",
-        "ScM" : "almonds",
-        "ScH" : "hazelnuts",
-        "ScW" : "Walnuts",
-        "ScC" : "cashew nuts",
-        "ScP" : "pistachios",
-        "Se" : "sesame seeds",
-        "Sf" : "mustard",
-        "Sl" : "celery",
-        "So" : "soy",
-        "Sw" : "sulfur dioxide and sulfites",
-        "Wt" : "mollusks",
-    ]
 
     enum CodingKeys: String, CodingKey {
         case name
         case prices
-        case ingredients
+        case labels
         case dishType = "dish_type"
     }
     

--- a/TUM Campus App/Cafeteria/Label.swift
+++ b/TUM Campus App/Cafeteria/Label.swift
@@ -1,0 +1,35 @@
+//
+//  Label.swift
+//  TUMCampusApp
+//
+//  Created by Philipp Wenner on 12.01.22.
+//  Copyright © 2022 TUM. All rights reserved.
+//
+
+import Foundation
+
+struct Label: Decodable {
+
+    /*
+     [
+       {
+         "enum_name": "VEGETARIAN",
+         "text": {
+           "DE": "Vegetarisch",
+           "EN": "vegetarian"
+         },
+         "abbreviation": "🌽"
+       }
+     ]
+     */
+
+    let name: String
+    let text: [String: String]
+    let abbreviation: String
+    
+    enum CodingKeys: String, CodingKey {
+        case name = "enum_name"
+        case text
+        case abbreviation
+    }
+}

--- a/TUM Campus App/Cafeteria/MensaEnumService.swift
+++ b/TUM Campus App/Cafeteria/MensaEnumService.swift
@@ -1,0 +1,29 @@
+//
+//  MensaEnumService.swift
+//  TUMCampusApp
+//
+//  Created by Philipp Wenner on 12.01.22.
+//  Copyright © 2022 TUM. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+
+final class MensaEnumService {
+    static let shared = MensaEnumService()
+    private var labels: [String:Label]?
+    
+    public func getLabels() -> [String:Label] {
+        if self.labels == nil {
+            self.labels = [:]
+            AF.request(EatAPI.labels).responseDecodable(of: [Label].self) { (response) in
+                let labels = response.value ?? []
+                for label in labels{
+                    self.labels?[label.name] = label
+                }
+            }
+        }
+        
+        return self.labels!
+    }
+}

--- a/TUM Campus App/Cafeteria/MenuCollectionViewCell.swift
+++ b/TUM Campus App/Cafeteria/MenuCollectionViewCell.swift
@@ -42,7 +42,20 @@ final class MenuCollectionViewCell: UICollectionViewCell {
             priceLabel.text = "n/a".localized
         }
 
-        ingredientsLabel.text = dish.labels.joined(separator: ", ")
+        ingredientsLabel.text = labelsToAbbreviations(labels: dish.labels).joined(separator: ", ")
+    }
+    
+    private func labelsToAbbreviations(labels: [String]) -> [String] {
+        let labelLookup = MensaEnumService.shared.getLabels()
+        var converted: [String] = []
+        for label in labels{
+            if let labelObject = labelLookup[label]{
+                converted.append(labelObject.abbreviation)
+            }else{
+                converted.append(label)
+            }
+        }
+        return converted
     }
 
     override func awakeFromNib() {

--- a/TUM Campus App/Cafeteria/MenuCollectionViewCell.swift
+++ b/TUM Campus App/Cafeteria/MenuCollectionViewCell.swift
@@ -42,7 +42,7 @@ final class MenuCollectionViewCell: UICollectionViewCell {
             priceLabel.text = "n/a".localized
         }
 
-        ingredientsLabel.text = dish.namedIngredients.joined(separator: ", ")
+        ingredientsLabel.text = dish.labels.joined(separator: ", ")
     }
 
     override func awakeFromNib() {

--- a/TUM Campus App/Cafeteria/MenuCollectionViewController.swift
+++ b/TUM Campus App/Cafeteria/MenuCollectionViewController.swift
@@ -30,6 +30,16 @@ final class MenuCollectionViewController: UICollectionViewController, UICollecti
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.navigationBar.prefersLargeTitles = true
+        
+        let infoButton = UIButton(type: .infoLight)
+        infoButton.addTarget(self, action: #selector(openLabelsExplanation), for: .touchUpInside)
+        let infoBarButtonItem = UIBarButtonItem(customView: infoButton)
+        self.navigationItem.rightBarButtonItem = infoBarButtonItem
+    }
+    
+    @objc public func openLabelsExplanation() {
+        guard let destination = UIStoryboard(name: "Main", bundle: .main).instantiateViewController(withIdentifier: "MenuLabelsTableViewController") as? MenuLabelsTableViewController else { return }
+        navigationController?.pushViewController(destination, animated: true)
     }
 
     override func numberOfSections(in collectionView: UICollectionView) -> Int { categories.count }

--- a/TUM Campus App/Cafeteria/MenuLabelsTableViewController.swift
+++ b/TUM Campus App/Cafeteria/MenuLabelsTableViewController.swift
@@ -1,0 +1,48 @@
+//
+//  MenuLabelsViewController.swift
+//  TUMCampusApp
+//
+//  Created by Philipp Wenner on 24.01.22.
+//  Copyright © 2022 TUM. All rights reserved.
+//
+
+import UIKit
+
+class MenuLabelsTableViewController: UITableViewController {
+    private var labels: [Label] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Labels"
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetch()
+    }
+    
+    @objc private func fetch() {
+        self.labels = Array(MensaEnumService.shared.getLabels().values)
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return self.labels.count
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+            
+        // create a new cell if needed or reuse an old one
+        let cell:UITableViewCell = self.tableView.dequeueReusableCell(withIdentifier: "LabelCell", for: indexPath)
+        
+        // set the text from the data model
+        cell.textLabel?.text = self.labels[indexPath.row].abbreviation
+        cell.detailTextLabel?.text = self.labels[indexPath.row].text["DE"]
+        
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        print("You tapped cell number \(indexPath.row).")
+    }
+
+}


### PR DESCRIPTION
### Issue
The mensa tab is currently not working due to two issues:
- eat-api format has changed to use labels instead of ingredients on dish level
- For weeks 1-9 a leading `0` is required, to fetch the data

This PR fixes the two issues, and also loads the `labels.json` from the API, in order to show the short version of the (ingredient) labels

This fixes the following issue(s): 385

### Screenshots
Dish view:
![image](https://user-images.githubusercontent.com/1690395/149194540-365f8727-6d0c-4c1a-9465-0f0220c93738.png)

Widget:
![image](https://user-images.githubusercontent.com/1690395/149194662-61e3cdce-d8b5-4e7e-95d5-6751a92ccbe9.png)

### TODO
I will include a popup, in order to show the explanations for the (ingredient) labels, similar to the popup on the website.


Fixes #385
