### PR TITLE
Add labels to the mensa dishes

### DIFF
--- a/Campus-iOS/Map/Cafeterias/MealPlanViewModel.swift
+++ b/Campus-iOS/Map/Cafeterias/MealPlanViewModel.swift
@@ -76,5 +76,8 @@ final class MealPlanViewModel: ObservableObject {
                                         return MenuViewModel(title: formatter.string(from: $0.date), date: $0.date, categories: categories) }
                               )
         }
+        
+        // initiate loading of labels here, to prevent showing of placeholders
+        _ = MensaEnumService.shared.getLabels()
     }
 }

--- a/Campus-iOS/Map/Cafeterias/MenuView.swift
+++ b/Campus-iOS/Map/Cafeterias/MenuView.swift
@@ -46,7 +46,11 @@ struct DishView: View {
             }
         } label: {
             VStack(alignment: .leading, spacing: 10){
-                Text(dish.name)
+                HStack{
+                    Text(dish.name)
+                    Spacer()
+                    Image(systemName: "info.circle")
+                }
                 HStack{
                     Text(labelsToString(labels: dish.labels))
                     Spacer()
@@ -56,6 +60,7 @@ struct DishView: View {
                 .font(.footnote)
             }
         }
+        .buttonStyle(PlainButtonStyle()).accentColor(.clear).disabled(true)
         
     }
     

--- a/Campus-iOS/Map/Cafeterias/MenuView.swift
+++ b/Campus-iOS/Map/Cafeterias/MenuView.swift
@@ -44,16 +44,6 @@ struct DishView: View {
                     }
                 }
             }
-               
-            VStack{
-                ForEach(Array(dish.prices.keys).sorted(by: >), id: \.self) { key in
-                    HStack {
-                        Text(key)
-                        Spacer()
-                        Text(formatPrice(dish: dish, pricingGroup: key))
-                    }
-                }
-            }
         } label: {
             VStack(alignment: .leading, spacing: 10){
                 Text(dish.name)

--- a/Campus-iOS/Map/Cafeterias/MenuViewModel.swift
+++ b/Campus-iOS/Map/Cafeterias/MenuViewModel.swift
@@ -26,7 +26,6 @@ struct CategoryViewModel: Identifiable {
     var id = UUID()
     var name: String
     var dishes: [Dish]
-    var isExpanded: Bool = false
     
     init(name: String, dishes: [Dish]) {
         self.name = name


### PR DESCRIPTION
### Issue
Show the labels of the dishes in the cafeteria view and explain them.
Instead of a custom view, I chose to add the label descriptions to the disclosure group of a dish.

This PR is related to the labels introduced in #389 but is now based on the swiftUi branch.

### Screenshots
How it looks:
![Bildschirmfoto 2022-02-09 um 14 08 04](https://user-images.githubusercontent.com/1690395/153208796-77076bf8-9dbb-434b-bb84-15b582187754.png)

Actually, I tried to have the label explanations and extended prices side-by-side, but this broke, when the price format is too long:
![Bildschirmfoto 2022-02-09 um 14 11 44](https://user-images.githubusercontent.com/1690395/153209106-f27b88cf-b2cd-4e85-88d6-c7d87addbc2c.png)
If there are other ideas for the presentation, I would like to hear them.

