### PR TITLE
Add the mensa queue status to the overview

### DIFF
--- a/Campus-iOS/App.swift
+++ b/Campus-iOS/App.swift
@@ -106,7 +106,7 @@ struct CampusApp: App {
                         canteens: [],
                         selectedCanteenName: " ",
                         selectedAnnotationIndex: 0,
-                        selectedCanteen: Cafeteria(location: Location(latitude: 0, longitude: 0, address: " "), name: " ", id: " "))
+                        selectedCanteen: Cafeteria(location: Location(latitude: 0, longitude: 0, address: " "), name: " ", id: " ", queueStatusApi: nil))
             }
             .tag(3)
             .tabItem {

--- a/Campus-iOS/Map/MainView/MapContent.swift
+++ b/Campus-iOS/Map/MainView/MapContent.swift
@@ -125,13 +125,20 @@ struct MapContent: UIViewRepresentable {
                     cafeterias.sortByDistance(to: currentLocation)
                 }
                 
-                guard let cafeterias = response.value else { return }
-                
                 let annotations = cafeterias.map { Annotation(title: $0.name, coordinate: $0.coordinate) }
                 
                 mapView.addAnnotations(annotations)
                 
                 canteens = cafeterias
+                
+                for (index, cafeteria) in canteens.enumerated() {
+                    if let queue = cafeteria.queueStatusApi  {
+                        sessionManager.request(queue, method: .get).responseDecodable(of: Queue.self, decoder: JSONDecoder()){ [self] response in
+                            canteens[index].queue = response.value
+                            //canteens = cafeterias
+                        }
+                    }
+                }
 
                 /*var snapshot = NSDiffableDataSourceSnapshot<Section, Cafeteria>()
                 snapshot.appendSections([.main])

--- a/Campus-iOS/Map/MainView/PanelContent.swift
+++ b/Campus-iOS/Map/MainView/PanelContent.swift
@@ -60,15 +60,15 @@ struct PanelContent: View {
                     ProgressView()
                     ScrollViewReader { proxy in
                         List {
-                            ForEach (canteens.filter({ searchString.isEmpty ? true : $0.name.localizedCaseInsensitiveContains(searchString) }), id: \.name) { cafeteria in
-                                PanelRow(cafeteria: cafeteria)
+                            ForEach (canteens.indices.filter({ searchString.isEmpty ? true : canteens[$0].name.localizedCaseInsensitiveContains(searchString) }), id: \.self) { id in
+                                PanelRow(cafeteria: self.$canteens[id])
                                 .onTapGesture {
                                     withAnimation {
-                                        selectedCanteenName = cafeteria.name
-                                        selectedAnnotationIndex = canteens.firstIndex(of: cafeteria)!
-                                        proxy.scrollTo(cafeteria, anchor: .top)
+                                        selectedCanteenName = canteens[id].name
+                                        selectedAnnotationIndex = canteens.firstIndex(of: canteens[id])!
+                                        proxy.scrollTo(canteens[id], anchor: .top)
                                         
-                                        selectedCanteen = cafeteria
+                                        selectedCanteen = canteens[id]
                                     }
                                 }
                                 .task(id: selectedAnnotationIndex) {
@@ -80,6 +80,7 @@ struct PanelContent: View {
                                     }
                                 }
                             }
+
                         }
                     }
                     .searchable(text: $searchString, prompt: "Look for something")

--- a/Campus-iOS/Map/MainView/PanelRow.swift
+++ b/Campus-iOS/Map/MainView/PanelRow.swift
@@ -11,7 +11,8 @@ import MapKit
 
 struct PanelRow: View {
     
-    @State var cafeteria: Cafeteria
+    @Binding var cafeteria: Cafeteria
+    @State var explainStatus = false
     private let locationManager = CLLocationManager()
     private let distanceFormatter: MKDistanceFormatter = {
         let formatter = MKDistanceFormatter()
@@ -28,6 +29,15 @@ struct PanelRow: View {
                         Text(cafeteria.name)
                             .bold()
                             .font(.title3)
+                        Spacer()
+                        if let queue = cafeteria.queue {
+                            let explainText = explainStatus ? "Auslastung " : ""
+                            Text("\(explainText)\(Int(queue.percent))%")
+                                .font(.footnote)
+                                .onTapGesture {
+                                    explainStatus.toggle()
+                                }
+                        }
                     }
                     Spacer().frame(height: 0)
                     HStack {

--- a/Campus-iOS/Map/Types/Cafeteria.swift
+++ b/Campus-iOS/Map/Types/Cafeteria.swift
@@ -16,6 +16,11 @@ struct Location: Decodable, Hashable {
     var coordinate: CLLocationCoordinate2D { CLLocationCoordinate2D(latitude: latitude, longitude: longitude) }
 }
 
+struct Queue: Decodable, Hashable {
+    let current: Int
+    let percent: Float
+}
+
 struct Cafeteria: Decodable, Hashable {
     /*
      "location": {
@@ -28,8 +33,11 @@ struct Cafeteria: Decodable, Hashable {
      },
  */
     let location: Location
-    let name: String
+    var name: String
     let id: String
+    
+    let queueStatusApi: String?
+    var queue: Queue?
 
     var coordinate: CLLocationCoordinate2D { location.coordinate }
     var title: String? { name }
@@ -38,6 +46,8 @@ struct Cafeteria: Decodable, Hashable {
         case location
         case name
         case id = "canteen_id"
+        case queueStatusApi = "queue_status"
+        case queue
     }
     
 }


### PR DESCRIPTION
### Feature
Show the mensa queue length directly in the list view of the canteens.
The label will change to a descriptive version, if a user clicks on it (see 2. screenshot)

This fixes the following issue(s): 
#375 

### Screenshots
![Bildschirmfoto 2022-02-09 um 18 50 48](https://user-images.githubusercontent.com/1690395/153260218-2f752535-259b-4832-a9eb-732f9aabfe3d.png)

On tap of the label:
![Bildschirmfoto 2022-02-09 um 18 52 00](https://user-images.githubusercontent.com/1690395/153260400-2b67890d-21fc-43db-a442-8d7d9b9dd2ee.png)


