### PR TITLE
Feature/calendar redirect to room

### DIFF
--- a/Campus-iOS/App.swift
+++ b/Campus-iOS/App.swift
@@ -50,7 +50,7 @@ struct CampusApp: App {
     func tabViewComponent() -> some View {
         TabView(selection: $selectedTab) {
             NavigationView {
-                CalendarContentView()
+                CalendarContentView(model: model)
                     .navigationTitle("Calendar")
             }
             .tag(0)

--- a/Campus-iOS/CalendarComponent/ViewModel/CalendarViewModel.swift
+++ b/Campus-iOS/CalendarComponent/ViewModel/CalendarViewModel.swift
@@ -14,7 +14,10 @@ class CalendarViewModel: ObservableObject {
 
     @Published var events: [CalendarEvent] = []
     
-    init() {
+    let model: Model
+    
+    init(model: Model) {
+        self.model = model
         fetch()
     }
     

--- a/Campus-iOS/CalendarComponent/Views/CalendarContentView.swift
+++ b/Campus-iOS/CalendarComponent/Views/CalendarContentView.swift
@@ -10,19 +10,19 @@ import KVKCalendar
 
 struct CalendarContentView: View {
     
-    @EnvironmentObject private var model: Model
+    @StateObject var viewModel: CalendarViewModel
     @AppStorage("calendarWeekDays") var calendarWeekDays: Int = 7
     
     @State var selectedType: CalendarType = .week
     @State var selectedEventID: String?
     @State var isTodayPressed: Bool = false
-    
-    @ObservedObject var viewModel = CalendarViewModel()
 
+    init(model: Model) {
+        self._viewModel = StateObject(wrappedValue: CalendarViewModel(model: model))
+    }
     
     var body: some View {
-        VStack{
-            
+        VStack {
             GeometryReader { geo in
                 // workaround since passing the calendar type to the view does not work
                 switch self.selectedType {
@@ -54,7 +54,7 @@ struct CalendarContentView: View {
                 .first(where: { $0.id.description == eventId })
             CalendarSingleEventView(
                 viewModel: LectureDetailsViewModel(
-                                model: model,
+                    model: viewModel.model,
                                 service: LectureDetailsService(),
                                 // Yes, it is a really hacky solution...
                                 lecture: Lecture(id: UInt64(chosenEvent?.lvNr ?? "") ?? 0, lvNumber: UInt64(chosenEvent?.lvNr ?? "") ?? 0, title: "", duration: "", stp_sp_sst: "", eventTypeDefault: "", eventTypeTag: "", semesterYear: "", semesterType: "", semester: "", semesterID: "", organisationNumber: 0, organisation: "", organisationTag: "", speaker: "")
@@ -64,7 +64,7 @@ struct CalendarContentView: View {
         }
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarLeading) {
-                CalendarToolbar(model: self.model, viewModel: self.viewModel, selectedEventID: self.$selectedEventID, isTodayPressed: self.$isTodayPressed)
+                CalendarToolbar(viewModel: self.viewModel, selectedEventID: self.$selectedEventID, isTodayPressed: self.$isTodayPressed)
             }
             ToolbarItem(placement: .principal) {
                 Picker("Calendar Type", selection: $selectedType) {
@@ -93,7 +93,7 @@ struct CalendarContentView: View {
                 }
             }
             ToolbarItemGroup(placement: .navigationBarTrailing) {
-                ProfileToolbar(model: model)
+                ProfileToolbar(model: viewModel.model)
             }
         }
     }
@@ -104,9 +104,9 @@ struct CalendarContentView: View {
         return CGRect(x: origin.x, y: origin.y, width: geometry.size.width, height: geometry.size.height)
     }
 }
+
 struct CalendarContentView_Previews: PreviewProvider {
-    
     static var previews: some View {
-        CalendarContentView()
+        CalendarContentView(model: MockModel())
     }
 }

--- a/Campus-iOS/CalendarComponent/Views/CalendarDisplayView.swift
+++ b/Campus-iOS/CalendarComponent/Views/CalendarDisplayView.swift
@@ -109,3 +109,9 @@ struct CalendarDisplayView: UIViewRepresentable {
     }
     
 }
+
+//struct CalendarDisplayView_Previews: PreviewProvider {
+//    static var previews: some View {
+//        CalendarDisplayView(...)
+//    }
+//}

--- a/Campus-iOS/CalendarComponent/Views/CalendarSingleEventView.swift
+++ b/Campus-iOS/CalendarComponent/Views/CalendarSingleEventView.swift
@@ -23,7 +23,7 @@ struct CalendarSingleEventView: View {
                     Group {
                         switch viewModel.state {
                         case .success(let data):
-                            LecturesDetailView(lectureDetails: data, calendarEvent: chosenEvent)
+                            LecturesDetailView(viewModel: viewModel, lectureDetails: data, calendarEvent: chosenEvent)
                         case .loading, .na:
                             LoadingView(text: "Fetching details of event")
                         case .failed(let error):

--- a/Campus-iOS/CalendarComponent/Views/CalendarToolbar.swift
+++ b/Campus-iOS/CalendarComponent/Views/CalendarToolbar.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct CalendarToolbar: View {
-    @ObservedObject var model: Model
     @ObservedObject var viewModel: CalendarViewModel
     
     @Binding var selectedEventID: String?
@@ -26,7 +25,7 @@ struct CalendarToolbar: View {
                 .edgesIgnoringSafeArea(.all)
                 .toolbar {
                     ToolbarItemGroup(placement: .navigationBarTrailing) {
-                        ProfileToolbar(model: self.model)
+                        ProfileToolbar(model: self.viewModel.model)
                     }
                 }
             ) {
@@ -48,6 +47,6 @@ struct CalendarToolbar_Previews: PreviewProvider {
     static var model = MockModel()
     
     static var previews: some View {
-        CalendarToolbar(model: model, viewModel: CalendarViewModel(), selectedEventID: $selectedEventId, isTodayPressed: $todayPressed)
+        CalendarToolbar(viewModel: CalendarViewModel(model: model), selectedEventID: $selectedEventId, isTodayPressed: $todayPressed)
     }
 }

--- a/Campus-iOS/LectureComponent/Screen/LectureDetailsScreen.swift
+++ b/Campus-iOS/LectureComponent/Screen/LectureDetailsScreen.swift
@@ -24,7 +24,7 @@ struct LectureDetailsScreen: View {
         Group {
             switch vm.state {
             case .success(let data):
-                LecturesDetailView(lectureDetails: data)
+                LecturesDetailView(viewModel: vm, lectureDetails: data)
             case .loading, .na:
                 LoadingView(text: "Fetching details of lecture".localized)
             case .failed(let error):

--- a/Campus-iOS/LectureComponent/ViewModel/LectureDetailsViewModel.swift
+++ b/Campus-iOS/LectureComponent/ViewModel/LectureDetailsViewModel.swift
@@ -16,9 +16,9 @@ class LectureDetailsViewModel: LectureDetailsViewModelProtocol {
     @Published private(set) var state: State = .na
     @Published var hasError: Bool = false
     
-    private let model: Model
-    private let service: LectureDetailsServiceProtocol
-    private let lecture: Lecture
+    let model: Model
+    private let service: LectureDetailsServiceProtocol?
+    private let lecture: Lecture?
     
     var token: String? {
         switch self.model.loginController.credentials {
@@ -37,6 +37,12 @@ class LectureDetailsViewModel: LectureDetailsViewModelProtocol {
         self.lecture = lecture
     }
     
+    init(model: Model) {
+        self.model = model
+        self.service = nil
+        self.lecture = nil
+    }
+    
     func getLectureDetails(forcedRefresh: Bool = false) async {
         self.state = .loading
         self.hasError = false
@@ -47,14 +53,16 @@ class LectureDetailsViewModel: LectureDetailsViewModelProtocol {
             return
         }
         
-        do {
-            self.state = .success(
-                data: try await service.fetch(token: token, lvNr: self.lecture.id, forcedRefresh: forcedRefresh)
-            )
-        } catch {
-            print(error)
-            self.state = .failed(error: error)
-            self.hasError = true
+        if let service = service, let lecture = lecture {
+            do {
+                self.state = .success(
+                    data: try await service.fetch(token: token, lvNr: lecture.id, forcedRefresh: forcedRefresh)
+                )
+            } catch {
+                print(error)
+                self.state = .failed(error: error)
+                self.hasError = true
+            }
         }
     }
 }

--- a/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsBasicInfoRowView.swift
+++ b/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsBasicInfoRowView.swift
@@ -18,6 +18,7 @@ struct LectureDetailsBasicInfoRowView: View {
                 .frame(width: 25, height: 25, alignment: .center)
             Text(text)
                 .font(.system(size: 16))
+                .multilineTextAlignment(.leading)
         }
     }
 }
@@ -26,7 +27,7 @@ struct LectureDetailsRowView_Previews: PreviewProvider {
     static var previews: some View {
         LectureDetailsBasicInfoRowView(
             iconName: "number",
-            text: "test"
+            text: "LOOOOOOOOOOOOOOOOOOONG (1234.01.001)"
         )
     }
 }

--- a/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
+++ b/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct LectureDetailsEventInfoView: View {
+    @StateObject var viewModel: LectureDetailsViewModel
     var event: CalendarEvent
     
     var duration: String {
@@ -38,10 +39,13 @@ struct LectureDetailsEventInfoView: View {
                     text: self.duration
                 )
                 Divider()
-                LectureDetailsBasicInfoRowView(
-                    iconName: "rectangle.portrait.arrowtriangle.2.inward",
-                    text: self.location
-                )
+                // Open RoomfinderView
+                NavigationLink(destination: RoomFinderView(model: viewModel.model, viewModel: RoomFinderViewModel(), searchText: self.location)) { // TODO: searchText should just be the room number -> filter the string
+                    LectureDetailsBasicInfoRowView(
+                        iconName: "rectangle.portrait.arrowtriangle.2.inward",
+                        text: self.location
+                    )
+                }
             }
         }
         .frame(
@@ -70,6 +74,6 @@ struct LectureDetailsEventInfoView_Previews: PreviewProvider {
     static var event = CalendarEvent(id: 1, title: "Some Title", descriptionText: "Some description", startDate: Date(), endDate: Date(), location: "Some Location")
     
     static var previews: some View {
-        LectureDetailsEventInfoView(event: event)
+        LectureDetailsEventInfoView(viewModel: LectureDetailsViewModel(model: MockModel()), event: event)
     }
 }

--- a/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
+++ b/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
@@ -71,7 +71,7 @@ struct LectureDetailsEventInfoView: View {
 
 struct LectureDetailsEventInfoView_Previews: PreviewProvider {
     
-    static var event = CalendarEvent(id: 1, title: "Some Title", descriptionText: "Some description", startDate: Date(), endDate: Date(), location: "Some Location")
+    static var event = CalendarEvent(id: 1, title: "Some Title", descriptionText: "Some description", startDate: Date(), endDate: Date(), location: "Some long long long long long location (1234.01.001)")
     
     static var previews: some View {
         LectureDetailsEventInfoView(viewModel: LectureDetailsViewModel(model: MockModel()), event: event)

--- a/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
+++ b/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
@@ -40,7 +40,7 @@ struct LectureDetailsEventInfoView: View {
                 )
                 Divider()
                 // Open RoomfinderView
-                NavigationLink(destination: RoomFinderView(model: viewModel.model, viewModel: RoomFinderViewModel(), searchText: self.location)) { // TODO: searchText should just be the room number -> filter the string
+                NavigationLink(destination: RoomFinderView(model: viewModel.model, viewModel: RoomFinderViewModel(), searchText: extract(room: self.location))) {
                     LectureDetailsBasicInfoRowView(
                         iconName: "rectangle.portrait.arrowtriangle.2.inward",
                         text: self.location
@@ -67,6 +67,20 @@ struct LectureDetailsEventInfoView: View {
         formatter.dateFormat = "HH:mm"
         return formatter
     }()
+    
+    func extract(room: String) -> String {
+        var roomNumber = room
+
+        if let openBraceRange = roomNumber.range(of: "(") {
+            roomNumber.removeSubrange(roomNumber.startIndex..<openBraceRange.upperBound)
+        }
+        
+        if let closeBraceRange = roomNumber.range(of: ")") {
+            roomNumber.removeSubrange(closeBraceRange.lowerBound..<roomNumber.endIndex)
+        }
+        
+        return roomNumber
+    }
 }
 
 struct LectureDetailsEventInfoView_Previews: PreviewProvider {

--- a/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
+++ b/Campus-iOS/LectureComponent/Views/LectureDetailsViews/LectureDetailsEventInfoView.swift
@@ -40,12 +40,24 @@ struct LectureDetailsEventInfoView: View {
                 )
                 Divider()
                 // Open RoomfinderView
-                NavigationLink(destination: RoomFinderView(model: viewModel.model, viewModel: RoomFinderViewModel(), searchText: extract(room: self.location))) {
+                VStack (alignment: .leading) {
                     LectureDetailsBasicInfoRowView(
                         iconName: "rectangle.portrait.arrowtriangle.2.inward",
                         text: self.location
                     )
+                    HStack {
+                        Spacer()
+                        NavigationLink(destination: RoomFinderView(model: viewModel.model, viewModel: RoomFinderViewModel(), searchText: extract(room: self.location))) {
+                            HStack {
+                                Text("Open in RoomFinder")
+                                Image(systemName: "arrow.right.circle")
+                            }.foregroundColor(Color(UIColor.tumBlue))
+                                .font(.footnote)
+                        }
+                    }
                 }
+                
+                
             }
         }
         .frame(

--- a/Campus-iOS/LectureComponent/Views/LecturesDetailView.swift
+++ b/Campus-iOS/LectureComponent/Views/LecturesDetailView.swift
@@ -23,7 +23,6 @@ struct LecturesDetailView: View {
                 VStack(alignment: .leading, spacing: 20) {
                     
                     if let event = self.calendarEvent {
-                        // TODO: Should open room search once implemented
                         LectureDetailsEventInfoView(viewModel: viewModel, event: event)
                     }
                     

--- a/Campus-iOS/LectureComponent/Views/LecturesDetailView.swift
+++ b/Campus-iOS/LectureComponent/Views/LecturesDetailView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct LecturesDetailView: View {
+    @StateObject var viewModel: LectureDetailsViewModel
     var lectureDetails: LectureDetails
     var calendarEvent: CalendarEvent?
     
@@ -23,7 +24,7 @@ struct LecturesDetailView: View {
                     
                     if let event = self.calendarEvent {
                         // TODO: Should open room search once implemented
-                        LectureDetailsEventInfoView(event: event)
+                        LectureDetailsEventInfoView(viewModel: viewModel, event: event)
                     }
                     
                     LectureDetailsBasicInfoView(lectureDetails: lectureDetails)
@@ -47,6 +48,6 @@ struct LectureDetailView_Previews: PreviewProvider {
     static var event = CalendarEvent(id: 1, title: "Some Title", descriptionText: "Some description", startDate: Date(), endDate: Date(), location: "Some Location")
     
     static var previews: some View {
-        LecturesDetailView(lectureDetails: LectureDetails.dummyData, calendarEvent: event)
+        LecturesDetailView(viewModel: LectureDetailsViewModel(model: MockModel()), lectureDetails: LectureDetails.dummyData, calendarEvent: event)
     }
 }

--- a/Campus-iOS/RoomFinder/Views/RoomFinderView.swift
+++ b/Campus-iOS/RoomFinder/Views/RoomFinderView.swift
@@ -19,10 +19,20 @@ struct RoomFinderView: View {
             .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
             .onChange(of: self.searchText) { searchValue in
                 if searchValue.count > 3 {
-                    self.viewModel.fetch(searchString: searchValue)
+                    search(searchValue)
+                }
+            }
+            .onAppear {
+                if !searchText.isEmpty {
+                    search(searchText)
                 }
             }
             .animation(.default, value: self.viewModel.result)
+        
+    }
+    
+    func search(_ searchValue: String) {
+        self.viewModel.fetch(searchString: searchValue)
     }
 }
 


### PR DESCRIPTION
### Issue
Adding a redirect to the `RoomFinderView` when viewing a lecture from the calendar.

This fixes the following issue(s):
Now it's possible to directly find a room from within the `LectureDetailsEventInfoView`.

### Screenshots
<img width="484" alt="Screenshot 2022-07-22 at 14 59 26" src="https://user-images.githubusercontent.com/59373377/180444274-ce2f6072-6cc7-4103-8523-376787c54820.png">
<img width="484" alt="Screenshot 2022-07-22 at 14 59 28" src="https://user-images.githubusercontent.com/59373377/180444284-59120036-6681-4c6c-b1c3-d5018dabdb48.png">

