### PR TITLE
Fix/news background crash

### DIFF
--- a/Campus-iOS/NewsComponent/ViewModel/NewsViewModel.swift
+++ b/Campus-iOS/NewsComponent/ViewModel/NewsViewModel.swift
@@ -8,30 +8,36 @@
 import Alamofire
 import FirebaseCrashlytics
 
+@MainActor
 class NewsViewModel: ObservableObject {
 
     @Published var newsSources = [NewsSource]()
+    @Published var news = [News]()
+    @Published var sourcesAndNews = [(Int64?, [News])]()
+    //@Published var news = [News]()
     
-    typealias ImporterType = Importer<NewsSource, [NewsSource], JSONDecoder>
     private let sessionManager: Session = Session.defaultSession
     
     init() {
         // TODO: Get from cache, if not found, then fetch
         
         fetch()
+//        fetchNews(sourceId: 1)
     }
     
     var latestFiveNews: [(String?, News?)] {
-        let latestNews = self.newsSources
-            .map({$0.news})
-            .reduce([], +)
-            .filter({$0.created != nil && $0.sourceID != 2})
-            .sorted(by: {
-                guard let date1 = $0.created, let date2 = $1.created else {
-                    return false
-                }
-                return date1.compare(date2) == .orderedDescending
-            })[...4]
+        print(">> latestFiveNews loaded")
+        let latestNews = [News(id: "TEST_id1234", sourceId: 123, date: Date(), created: Date(), title: "Title", link: nil, imageURL: nil)]
+//        Array(self.newsSources
+//            .map({$0.news})
+//            .reduce([], +)
+//            .filter({$0.created != nil && $0.sourceID != 2})
+//            .sorted(by: {
+//                guard let date1 = $0.created, let date2 = $1.created else {
+//                    return false
+//                }
+//                return date1.compare(date2) == .orderedDescending
+//            }).prefix(5))
         
         let latestFiveNews = latestNews.map { news in
             (newsSources.first(where: {$0.id == news.sourceID})?.title, news)
@@ -41,6 +47,8 @@ class NewsViewModel: ObservableObject {
     }
     
     func fetch() {
+        typealias ImporterType = Importer<NewsSource, [NewsSource], JSONDecoder>
+        
         let endpoint: URLRequestConvertible = TUMCabeAPI.newsSources
         let dateDecodingStrategy: JSONDecoder.DateDecodingStrategy? = .formatted(.yyyyMMddhhmmss)
         let importer = ImporterType(endpoint: endpoint, dateDecodingStrategy: dateDecodingStrategy)
@@ -48,7 +56,39 @@ class NewsViewModel: ObservableObject {
         importer.performFetch(handler: { result in
             switch result {
             case .success(let incoming):
+                incoming.forEach { newsSource in
+                    self.fetchNews(sourceId: newsSource.id)
+                }
+                
                 self.newsSources = incoming
+            case .failure(let error):
+                print(error)
+            }
+        })
+    }
+    
+    func fetchNews(sourceId: Int64?) {
+        typealias ImporterTypeNews = Importer<News, [News], JSONDecoder>
+
+        guard let id = sourceId else {
+            print("NewsSource contains no id")
+            return
+        }
+
+        let endpointNews: URLRequestConvertible = TUMCabeAPI.news(source: id.description)
+        let dateDecodingStrategyNews: JSONDecoder.DateDecodingStrategy? = .formatted(.yyyyMMddhhmmss)
+        let importerNews = ImporterTypeNews(endpoint: endpointNews, dateDecodingStrategy: dateDecodingStrategyNews)
+
+        importerNews.performFetch(handler: { result in
+            switch result {
+            case .success(let storage):
+                let news = storage.filter( {
+                    guard let title = $0.title, let link = $0.link else {
+                        return false
+                    }
+                    return !title.isEmpty && !link.description.isEmpty
+                } )
+                self.sourcesAndNews.append((sourceId, news))
             case .failure(let error):
                 print(error)
             }

--- a/Campus-iOS/NewsComponent/ViewModel/NewsViewModel.swift
+++ b/Campus-iOS/NewsComponent/ViewModel/NewsViewModel.swift
@@ -27,17 +27,16 @@ class NewsViewModel: ObservableObject {
     
     var latestFiveNews: [(String?, News?)] {
         print(">> latestFiveNews loaded")
-        let latestNews = [News(id: "TEST_id1234", sourceId: 123, date: Date(), created: Date(), title: "Title", link: nil, imageURL: nil)]
-//        Array(self.newsSources
-//            .map({$0.news})
-//            .reduce([], +)
-//            .filter({$0.created != nil && $0.sourceID != 2})
-//            .sorted(by: {
-//                guard let date1 = $0.created, let date2 = $1.created else {
-//                    return false
-//                }
-//                return date1.compare(date2) == .orderedDescending
-//            }).prefix(5))
+        let latestNews = Array(self.newsSources
+            .map({$0.news})
+            .reduce([], +)
+            .filter({$0.created != nil && $0.sourceID != 2})
+            .sorted(by: {
+                guard let date1 = $0.created, let date2 = $1.created else {
+                    return false
+                }
+                return date1.compare(date2) == .orderedDescending
+            }).prefix(5))
         
         let latestFiveNews = latestNews.map { news in
             (newsSources.first(where: {$0.id == news.sourceID})?.title, news)

--- a/Campus-iOS/NewsComponent/Views/NewsView.swift
+++ b/Campus-iOS/NewsComponent/Views/NewsView.swift
@@ -66,31 +66,6 @@ struct NewsView: View {
                 }
             }
         }
-//        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { (_) in
-//            print("UIApplication: active")
-//            viewModel.fetch()
-//          }
-        
-//        List(viewModel.newsSources.filter({$0.id != 2}), id: \.id) { newsSource in
-//            Section(newsSource.title ?? "NIL") {
-//                ForEach(newsSource.news, id: \.id) { news in
-//                    Text(news.title ?? "NIL")
-//                }
-//            }
-//        }
-//
-//
-//        List(viewModel.news, id: \.id) { news in
-//            Text(news.title ?? "NIL")
-//        }
-
-//        List(viewModel.sourcesAndNews, id: \.0) { sourceAndNews in
-//            Section(String(sourceAndNews.0 ?? 0)) {
-//                ForEach(sourceAndNews.1, id: \.id) { news in
-//                    Text(news.title ?? "NIL")
-//                }
-//            }
-//        }
     }
     
     init(viewModel: NewsViewModel) {

--- a/Campus-iOS/NewsComponent/Views/NewsView.swift
+++ b/Campus-iOS/NewsComponent/Views/NewsView.swift
@@ -16,58 +16,57 @@ struct NewsView: View {
     @State var selectedLink: URL? = nil
     
     var body: some View {
-//        ScrollView(.vertical) {
-//            VStack(alignment: .center) {
-//                ScrollView(.horizontal, showsIndicators: false) {
-//                    HStack(spacing: 30) {
-//                        ForEach(viewModel.latestFiveNews, id: \.1?.id) { oneLatestNews in
-//                            GeometryReader { geometry in
-//                                if let url = oneLatestNews.1?.link {
-//                                    if self.useBuildInWebView {
-//                                        NewsCard(news: oneLatestNews, latest: true)
-//                                            .padding()
-//                                            .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
-//                                            .onTapGesture {
-//                                                self.selectedLink = oneLatestNews.1?.link
-//                                            }
-//                                    } else {
-//                                        Link(destination: url) {
-//                                            NewsCard(news: oneLatestNews, latest: true)
-//                                                .padding()
-//                                                .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
-//                                        }
-//                                    }
-//                                }
-//                            }
-//                            .frame(width: 250, height: 350)
-//                            // adjust height
-//                            Spacer(minLength: 1)
-//                        }.sheet(item: $selectedLink) { selectedLink in
-//                            if let link = selectedLink {
-//                                SFSafariViewWrapper(url: link)
-//                            }
-//                        }
-//                        Spacer()
-//                    }.padding()
-//                }
-//
-//
-//
-//                Spacer()
-//                ForEach(viewModel.newsSources.filter({!$0.news.isEmpty && $0.id != 2}), id: \.id) { source in
-//                    Collapsible(title: {
-//                        AnyView(HStack(alignment: .center) {
-//                            Image(systemName: "list.bullet").foregroundColor(.blue)
-//                            Text(source.title ?? "")
-//                                .fontWeight(.bold)
-//                                .font(.headline)
-//                        })
-//                    }) {
-//                        NewsCardsHorizontalScrollingView(news: source.news)
-//                    }.modifier(ScrollableCardsViewModifier())
-//                }
-//            }
-//        }.onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { (_) in
+        ScrollView(.vertical) {
+            VStack(alignment: .center) {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 30) {
+                        ForEach(viewModel.latestFiveNews, id: \.1?.id) { oneLatestNews in
+                            GeometryReader { geometry in
+                                if let url = oneLatestNews.1?.link {
+                                    if self.useBuildInWebView {
+                                        NewsCard(news: oneLatestNews, latest: true)
+                                            .padding()
+                                            .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
+                                            .onTapGesture {
+                                                self.selectedLink = oneLatestNews.1?.link
+                                            }
+                                    } else {
+                                        Link(destination: url) {
+                                            NewsCard(news: oneLatestNews, latest: true)
+                                                .padding()
+                                                .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
+                                        }
+                                    }
+                                }
+                            }
+                            .frame(width: 250, height: 350)
+                            // adjust height
+                            Spacer(minLength: 1)
+                        }.sheet(item: $selectedLink) { selectedLink in
+                            if let link = selectedLink {
+                                SFSafariViewWrapper(url: link)
+                            }
+                        }
+                        Spacer()
+                    }.padding()
+                }
+
+                Spacer()
+                ForEach(viewModel.newsSources.filter({!$0.news.isEmpty && $0.id != 2}), id: \.id) { source in
+                    Collapsible(title: {
+                        AnyView(HStack(alignment: .center) {
+                            Image(systemName: "list.bullet").foregroundColor(.blue)
+                            Text(source.title ?? "")
+                                .fontWeight(.bold)
+                                .font(.headline)
+                        })
+                    }) {
+                        NewsCardsHorizontalScrollingView(news: source.news)
+                    }.modifier(ScrollableCardsViewModifier())
+                }
+            }
+        }
+//        .onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { (_) in
 //            print("UIApplication: active")
 //            viewModel.fetch()
 //          }
@@ -79,19 +78,24 @@ struct NewsView: View {
 //                }
 //            }
 //        }
-        
-        
+//
+//
 //        List(viewModel.news, id: \.id) { news in
 //            Text(news.title ?? "NIL")
 //        }
 
-        List(viewModel.sourcesAndNews, id: \.0) { sourceAndNews in
-            Section(String(sourceAndNews.0 ?? 0)) {
-                ForEach(sourceAndNews.1, id: \.id) { news in
-                    Text(news.title ?? "NIL")
-                }
-            }
-        }
+//        List(viewModel.sourcesAndNews, id: \.0) { sourceAndNews in
+//            Section(String(sourceAndNews.0 ?? 0)) {
+//                ForEach(sourceAndNews.1, id: \.id) { news in
+//                    Text(news.title ?? "NIL")
+//                }
+//            }
+//        }
+    }
+    
+    init(viewModel: NewsViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        viewModel.fetch()
     }
 }
 

--- a/Campus-iOS/NewsComponent/Views/NewsView.swift
+++ b/Campus-iOS/NewsComponent/Views/NewsView.swift
@@ -9,59 +9,86 @@ import SwiftUI
 
 struct NewsView: View {
     
-    @ObservedObject var viewModel: NewsViewModel
+    @StateObject var viewModel: NewsViewModel
     @AppStorage("useBuildInWebView") var useBuildInWebView: Bool = true
+    @Environment(\.scenePhase) var scenePhase
     @State var isWebViewShowed = false
     @State var selectedLink: URL? = nil
     
     var body: some View {
-        ScrollView(.vertical) {
-            VStack(alignment: .center) {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 30) {
-                        ForEach(viewModel.latestFiveNews, id: \.1?.id) { oneLatestNews in
-                            GeometryReader { geometry in
-                                if let url = oneLatestNews.1?.link {
-                                    if self.useBuildInWebView {
-                                        NewsCard(news: oneLatestNews, latest: true)
-                                            .padding()
-                                            .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
-                                            .onTapGesture {
-                                                self.selectedLink = oneLatestNews.1?.link
-                                            }
-                                    } else {
-                                        Link(destination: url) {
-                                            NewsCard(news: oneLatestNews, latest: true)
-                                                .padding()
-                                                .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
-                                        }
-                                    }
-                                }
-                            }
-                            .frame(width: 250, height: 350)
-                            // adjust height
-                            Spacer(minLength: 1)
-                        }.sheet(item: $selectedLink) { selectedLink in 
-                            if let link = selectedLink {
-                                SFSafariViewWrapper(url: link)
-                            }
-                        }
-                        Spacer()
-                    }.padding()
-                }
-                
-                Spacer()
-                ForEach(viewModel.newsSources.filter({!$0.news.isEmpty && $0.id != 2}), id: \.id) { source in
-                    Collapsible(title: {
-                        AnyView(HStack(alignment: .center) {
-                            Image(systemName: "list.bullet").foregroundColor(.blue)
-                            Text(source.title ?? "")
-                                .fontWeight(.bold)
-                                .font(.headline)
-                        })
-                    }) {
-                        NewsCardsHorizontalScrollingView(news: source.news)
-                    }.modifier(ScrollableCardsViewModifier())
+//        ScrollView(.vertical) {
+//            VStack(alignment: .center) {
+//                ScrollView(.horizontal, showsIndicators: false) {
+//                    HStack(spacing: 30) {
+//                        ForEach(viewModel.latestFiveNews, id: \.1?.id) { oneLatestNews in
+//                            GeometryReader { geometry in
+//                                if let url = oneLatestNews.1?.link {
+//                                    if self.useBuildInWebView {
+//                                        NewsCard(news: oneLatestNews, latest: true)
+//                                            .padding()
+//                                            .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
+//                                            .onTapGesture {
+//                                                self.selectedLink = oneLatestNews.1?.link
+//                                            }
+//                                    } else {
+//                                        Link(destination: url) {
+//                                            NewsCard(news: oneLatestNews, latest: true)
+//                                                .padding()
+//                                                .rotation3DEffect(Angle(degrees: Double(geometry.frame(in: .global).minX - 50) / -20), axis: (x: 0, y: 100.0, z: 0))
+//                                        }
+//                                    }
+//                                }
+//                            }
+//                            .frame(width: 250, height: 350)
+//                            // adjust height
+//                            Spacer(minLength: 1)
+//                        }.sheet(item: $selectedLink) { selectedLink in
+//                            if let link = selectedLink {
+//                                SFSafariViewWrapper(url: link)
+//                            }
+//                        }
+//                        Spacer()
+//                    }.padding()
+//                }
+//
+//
+//
+//                Spacer()
+//                ForEach(viewModel.newsSources.filter({!$0.news.isEmpty && $0.id != 2}), id: \.id) { source in
+//                    Collapsible(title: {
+//                        AnyView(HStack(alignment: .center) {
+//                            Image(systemName: "list.bullet").foregroundColor(.blue)
+//                            Text(source.title ?? "")
+//                                .fontWeight(.bold)
+//                                .font(.headline)
+//                        })
+//                    }) {
+//                        NewsCardsHorizontalScrollingView(news: source.news)
+//                    }.modifier(ScrollableCardsViewModifier())
+//                }
+//            }
+//        }.onReceive(NotificationCenter.default.publisher(for: UIApplication.didBecomeActiveNotification)) { (_) in
+//            print("UIApplication: active")
+//            viewModel.fetch()
+//          }
+        
+//        List(viewModel.newsSources.filter({$0.id != 2}), id: \.id) { newsSource in
+//            Section(newsSource.title ?? "NIL") {
+//                ForEach(newsSource.news, id: \.id) { news in
+//                    Text(news.title ?? "NIL")
+//                }
+//            }
+//        }
+        
+        
+//        List(viewModel.news, id: \.id) { news in
+//            Text(news.title ?? "NIL")
+//        }
+
+        List(viewModel.sourcesAndNews, id: \.0) { sourceAndNews in
+            Section(String(sourceAndNews.0 ?? 0)) {
+                ForEach(sourceAndNews.1, id: \.id) { news in
+                    Text(news.title ?? "NIL")
                 }
             }
         }


### PR DESCRIPTION
### Issue
The app crashed in the background when the `NewsView` was open.

This fixes the following issue(s): 
Changing the ViewModel's type to `StateObejct` and adapting the filtering of the `fiveLatestNews` property. 
