### PR TITLE
Redesign/accessibility

### DIFF
--- a/Campus-iOS/Base/Views/FailedView.swift
+++ b/Campus-iOS/Base/Views/FailedView.swift
@@ -19,7 +19,7 @@ struct FailedView: View {
     var body: some View {
         GeometryReader { geo in
             ZStack {
-                Image("Error-logo-transparent")
+                Image(decorative: "Error-logo-transparent")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .offset(y: -geo.size.height*0.1)

--- a/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
@@ -78,6 +78,7 @@
 "Log in Successfull" = "Log in Successfull";
 "Next" = "Next";
 "Continue without TUM ID" = "Continue without TUM ID";
+"Try again" = "Try again";
 
 // TokenConfirmationView
 "Back" = "Back";

--- a/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
@@ -65,7 +65,11 @@
 "First 2 letters of TUM ID" = "First 2 letters of TUM ID";
 "2 numbers in the middle of TUM ID" = "2 numbers in the middle of TUM ID";
 "Last 3 letters of TUM ID" = "Last 3 letters of TUM ID";
-
+"This is a list with " = "This is a list with ";
+" entries" = " entries";
+"This Button opens a WebView" = "This Button opens a WebView";
+"List element" = "List element";
+" of " = " of ";
 
 // LoginView
 "Welcome to TUM Campus App" = "Welcome to TUM Campus App";

--- a/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
@@ -107,6 +107,7 @@
 "Token Permissions" = "Token Permissions";
 "Token Permissions (You are logged out)" = "Token Permissions (You are logged out)";
 "Calendar days in week mode" = "Calendar days in week mode";
+"This Link leaves the App" = "This Link leaves the App";
 
 // CalendarView
 "Day" = "Day";

--- a/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/Base.lproj/Localizable.strings
@@ -74,6 +74,7 @@
 "42" = "42";
 "tum" = "tum";
 "Log in 🎓" = "Log in 🎓";
+"Log in" = "Log in";
 "Log in Successfull" = "Log in Successfull";
 "Next" = "Next";
 "Continue without TUM ID" = "Continue without TUM ID";

--- a/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
@@ -60,6 +60,12 @@
 "Done" = "Fertig";
 "Places" = "Orte";
 "My Widgets" = "Meine Widgets";
+"This is a list with " = "Dies ist eine Liste mit ";
+" entries" = " Einträgen";
+"This Button opens a WebView" = "Dieser Link öffnet eine Website in der App";
+"List element" = "Listen Element";
+" of " = " von ";
+
 
 // LoginView
 "Welcome to TUM Campus App" = "Wilkommen zur TUM Campus App";

--- a/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
@@ -68,6 +68,7 @@
 "42" = "42";
 "tum" = "tum";
 "Log in 🎓" = "Einloggen 🎓";
+"Log in" = "Einloggen";
 "Log in Successfull" = "Eingeloggt";
 "Next" = "Weiter";
 "Continue without TUM ID" = "Weiter ohne TUM ID";

--- a/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
@@ -72,6 +72,7 @@
 "Log in Successfull" = "Eingeloggt";
 "Next" = "Weiter";
 "Continue without TUM ID" = "Weiter ohne TUM ID";
+"This Link leaves the App" = "Dieser Link verlässt die App";
 
 // TokenConfirmationView
 "Back" = "Zurück";

--- a/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
+++ b/Campus-iOS/Campus-iOS/de.lproj/Localizable.strings
@@ -73,6 +73,8 @@
 "Next" = "Weiter";
 "Continue without TUM ID" = "Weiter ohne TUM ID";
 "This Link leaves the App" = "Dieser Link verlässt die App";
+"Try again" = "Erneut versuchen";
+
 
 // TokenConfirmationView
 "Back" = "Zurück";

--- a/Campus-iOS/GradesComponent/Views/GradesView.swift
+++ b/Campus-iOS/GradesComponent/Views/GradesView.swift
@@ -35,6 +35,7 @@ struct GradesView: View {
                     Section(header: Text(gradesBySemester.0)
                         .font(.headline.bold())
                         .foregroundColor(Color("tumBlue"))
+                        .accessibilityHeading(.h2)
                     ) {
                         ForEach(gradesBySemester.1) { item in
                             VStack {

--- a/Campus-iOS/LectureComponent/Views/LecturesView.swift
+++ b/Campus-iOS/LectureComponent/Views/LecturesView.swift
@@ -32,6 +32,7 @@ struct LecturesView: View {
                 Section(header: Text(lecturesBySemester.0)
                     .font(.headline.bold())
                     .foregroundColor(Color("tumBlue"))
+                    .accessibilityHeading(.h2)
                 ) {
                     ForEach(lecturesBySemester.1) { item in
                         VStack {

--- a/Campus-iOS/LoginComponent/Views/LoginView.swift
+++ b/Campus-iOS/LoginComponent/Views/LoginView.swift
@@ -29,7 +29,7 @@ struct LoginView: View {
             GeometryReader { geo in
                 VStack {
                     VStack(alignment: .center) {
-                        Image("logo-blue")
+                        Image(decorative: "logo-blue")
                             .resizable()
                             .aspectRatio(contentMode: .fit)
                             .frame(width: geo.size.width * 0.4, height: geo.size.height / 8)
@@ -131,6 +131,7 @@ struct LoginView: View {
                                             .lineLimit(1)
                                             .font(.title3)
                                             .frame(alignment: .center)
+                                            .accessibilityLabel("Log in")
                                     }
                                 case .logInError:
                                     HStack {
@@ -152,7 +153,7 @@ struct LoginView: View {
                                 case .loggedIn:
                                     NavigationLink(destination:
                                                     TokenConfirmationView(viewModel: self.viewModel).navigationBarTitle(Text("Check Token")), isActive: $isActive) {
-                                        Text("Log in 🎓")
+                                        Text("Log in 🎓").accessibilityLabel("Log in")
                                             .lineLimit(1)
                                             .font(.title3)
                                             .frame(alignment: .center)
@@ -190,7 +191,7 @@ struct LoginView: View {
                     
                     Spacer()
                         
-                    Image("tower")
+                    Image(decorative: "tower")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: geo.size.width)

--- a/Campus-iOS/LoginComponent/Views/LoginView.swift
+++ b/Campus-iOS/LoginComponent/Views/LoginView.swift
@@ -36,6 +36,7 @@ struct LoginView: View {
                         .frame(alignment: .center)
                         .font(.title3 .bold())
                         .multilineTextAlignment(.center)
+                        .accessibilityHeading(.h3)
                 }
                 .frame(width: geo.size.width, height: geo.size.height / 4 )
                 
@@ -43,6 +44,7 @@ struct LoginView: View {
                 VStack(alignment: .center) {
                     Text("Enter your TUM ID to get started")
                         .font(.headline .bold())
+                        .accessibilityHeading(.h4)
                     
                     HStack() {
                         TextField("go", text: $viewModel.firstTextField)

--- a/Campus-iOS/LoginComponent/Views/LoginView.swift
+++ b/Campus-iOS/LoginComponent/Views/LoginView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Combine
 
 private enum Field: Int, Equatable {
-  case firstTextField, numbersTextField, secondTextField
+    case firstTextField, numbersTextField, secondTextField
 }
 
 
@@ -19,195 +19,178 @@ struct LoginView: View {
     @FocusState private var focusedField: Field?
     
     @State var isActive = true
-    
     @State var logInState: LoginViewModel.LoginState = .notChecked
     @State var showLoginAlert: Bool = false
     @State var buttonBackgroundColor: Color = .tumBlue
-    @State var showLoginButton: Bool = true
     
     var body: some View {
-            GeometryReader { geo in
-                VStack {
-                    VStack(alignment: .center) {
-                        Image(decorative: "logo-blue")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: geo.size.width * 0.4, height: geo.size.height / 8)
-                        
-                        Text("Welcome to TUM Campus App")
-                            .frame(alignment: .center)
-                            .font(.title3 .bold())
+        GeometryReader { geo in
+            VStack {
+                VStack(alignment: .center) {
+                    Image(decorative: "logo-blue")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: geo.size.width * 0.4, height: geo.size.height / 8)
+                    
+                    Text("Welcome to TUM Campus App")
+                        .frame(alignment: .center)
+                        .font(.title3 .bold())
+                        .multilineTextAlignment(.center)
+                }
+                .frame(width: geo.size.width, height: geo.size.height / 4 )
+                
+                Spacer()
+                VStack(alignment: .center) {
+                    Text("Enter your TUM ID to get started")
+                        .font(.headline .bold())
+                    
+                    HStack() {
+                        TextField("go", text: $viewModel.firstTextField)
+                            .textFieldStyle(CustomRoundedTextFieldStyle())
+                            .frame(width: 50)
+                            .font(.body)
                             .multilineTextAlignment(.center)
+                            .disableAutocorrection(true)
+                            .textContentType(.username)
+                            .textInputAutocapitalization(.never)
+                            .textCase(.lowercase)
+                            .focused($focusedField, equals: .firstTextField)
+                            .onChange(of: viewModel.firstTextField) {
+                                viewModel.firstTextField = String($0.prefix(2))
+                                if $0.count == 2 { focusedField = .numbersTextField }
+                            }
+                        
+                        Spacer().frame(width: 8)
+                        
+                        TextField("42", text: $viewModel.numbersTextField)
+                            .textFieldStyle(CustomRoundedTextFieldStyle())
+                            .frame(width: 50)
+                            .font(.body)
+                            .multilineTextAlignment(.center)
+                            .disableAutocorrection(true)
+                            .textContentType(.username)
+                            .keyboardType(.numberPad)
+                            .focused($focusedField, equals: .numbersTextField)
+                            .onChange(of: viewModel.numbersTextField) {
+                                viewModel.numbersTextField = String($0.prefix(2))
+                                if $0.count == 2 { focusedField = .secondTextField }
+                                if $0.count == 0 { focusedField = .firstTextField }
+                            }
+                        
+                        
+                        Spacer().frame(width: 8)
+                        
+                        TextField("tum", text: $viewModel.secondTextField)
+                            .textFieldStyle(CustomRoundedTextFieldStyle())
+                            .frame(width: 50)
+                            .font(.body)
+                            .multilineTextAlignment(.center)
+                            .disableAutocorrection(true)
+                            .textContentType(.username)
+                            .textInputAutocapitalization(.never)
+                            .textCase(.lowercase)
+                            .focused($focusedField, equals: .secondTextField)
+                            .onChange(of: viewModel.secondTextField) {
+                                viewModel.secondTextField = String($0.prefix(3))
+                                if $0.count == 3 { focusedField = nil }
+                                if $0.count == 0 { focusedField = .numbersTextField }
+                            }
+                        
                     }
-                    .frame(width: geo.size.width, height: geo.size.height / 4 )
                     
                     Spacer()
-                    VStack(alignment: .center) {
-                        Text("Enter your TUM ID to get started")
-                            .font(.headline .bold())
-
-                        HStack() {
-                            TextField("go", text: $viewModel.firstTextField)
-                                .textFieldStyle(CustomRoundedTextFieldStyle())
-                                .frame(width: 50)
-                                .font(.body)
-                                .multilineTextAlignment(.center)
-                                .disableAutocorrection(true)
-                                .textContentType(.username)
-                                .textInputAutocapitalization(.never)
-                                .textCase(.lowercase)
-                                .focused($focusedField, equals: .firstTextField)
-                                .onChange(of: viewModel.firstTextField) {
-                                    viewModel.firstTextField = String($0.prefix(2))
-                                    if $0.count == 2 { focusedField = .numbersTextField }
+                        .frame(height: 18)
+                    
+                    Button {
+                        if logInState != .loggedIn {
+                            self.viewModel.loginWithContinue() { result in
+                                switch result {
+                                case .success:
+                                    logInState = .loggedIn
+                                    print("Log in Successfull")
+                                case .failure(_):
+                                    logInState = .logInError
+                                    self.showLoginAlert = true
+                                    print("Loggin Error")
                                 }
-
-                            Spacer().frame(width: 8)
-
-                            TextField("42", text: $viewModel.numbersTextField)
-                                .textFieldStyle(CustomRoundedTextFieldStyle())
-                                .frame(width: 50)
-                                .font(.body)
-                                .multilineTextAlignment(.center)
-                                .disableAutocorrection(true)
-                                .textContentType(.username)
-                                .keyboardType(.numberPad)
-                                .focused($focusedField, equals: .numbersTextField)
-                                .onChange(of: viewModel.numbersTextField) {
-                                    viewModel.numbersTextField = String($0.prefix(2))
-                                    if $0.count == 2 { focusedField = .secondTextField }
-                                    if $0.count == 0 { focusedField = .firstTextField }
-                                }
-
-
-                            Spacer().frame(width: 8)
-
-                            TextField("tum", text: $viewModel.secondTextField)
-                                .textFieldStyle(CustomRoundedTextFieldStyle())
-                                .frame(width: 50)
-                                .font(.body)
-                                .multilineTextAlignment(.center)
-                                .disableAutocorrection(true)
-                                .textContentType(.username)
-                                .textInputAutocapitalization(.never)
-                                .textCase(.lowercase)
-                                .focused($focusedField, equals: .secondTextField)
-                                .onChange(of: viewModel.secondTextField) {
-                                    viewModel.secondTextField = String($0.prefix(3))
-                                    if $0.count == 3 { focusedField = nil }
-                                    if $0.count == 0 { focusedField = .numbersTextField }
-                                }
-                                
+                            }
                         }
-                        
-                        Spacer()
-                            .frame(height: 18)
-                        
-                        if showLoginButton {
-                            Button {
-                                if logInState != .loggedIn {
-                                    self.viewModel.loginWithContinue() { result in
-                                        switch result {
-                                        case .success:
-                                            withAnimation() {
-                                                buttonBackgroundColor = .blue
-                                                logInState = .loggedIn
-                                            }
-                                            print("Log in Successfull")
-                                        case .failure(_):
-                                            withAnimation() {
-                                                buttonBackgroundColor = .red
-                                                logInState = .logInError
-                                            }
-                                            print("Loggin Error")
-                                        }
-                                    }
-                                }
-                            } label: {
-                                switch logInState {
-                                case .notChecked:
-                                    HStack {
-                                        Text("Log in 🎓")
-                                            .lineLimit(1)
-                                            .font(.title3)
-                                            .frame(alignment: .center)
-                                            .accessibilityLabel("Log in")
-                                    }
-                                case .logInError:
-                                    HStack {
-                                        Image(systemName: "x.circle.fill")
-                                        Text("Login Error")
-                                    }
+                    } label : {
+                        switch logInState {
+                        case .notChecked:
+                            HStack {
+                                Text("Log in 🎓")
                                     .lineLimit(1)
                                     .font(.title3)
                                     .frame(alignment: .center)
-                                    .onAppear() {
-                                        Task {
-                                            try? await Task.sleep(nanoseconds: 1_500_000_000)
-                                            withAnimation() {
-                                                logInState = .notChecked
-                                                buttonBackgroundColor = .tumBlue
-                                            }
-                                        }
-                                    }
-                                case .loggedIn:
-                                    NavigationLink(destination:
-                                                    TokenConfirmationView(viewModel: self.viewModel).navigationBarTitle(Text("Check Token")), isActive: $isActive) {
-                                        Text("Log in 🎓").accessibilityLabel("Log in")
-                                            .lineLimit(1)
-                                            .font(.title3)
-                                            .frame(alignment: .center)
-                                    }
-                                }
-                                
+                                    .accessibilityLabel("Log in")
                             }
-                            .disabled(!viewModel.isContinueEnabled)
+                        case .logInError:
+                            Text("Try again")
                             .lineLimit(1)
-                            .font(.body)
-                            .frame(width: 200, height: 48, alignment: .center)
-                            .foregroundColor(.white)
-                            .background(buttonBackgroundColor)
-                            .cornerRadius(10)
-                            .buttonStyle(.plain)
+                            .font(.title3)
+                            .frame(alignment: .center)
+                        case .loggedIn:
+                            NavigationLink(destination:
+                                            TokenConfirmationView(viewModel: self.viewModel).navigationBarTitle(Text("Check Token")), isActive: $isActive) {
+                                Text("Log in 🎓").accessibilityLabel("Log in")
+                                    .lineLimit(1)
+                                    .font(.title3)
+                                    .frame(alignment: .center)
+                            }
                         }
-
-                        Spacer().frame(height: 20)
-
-                        
-                        Button(action: {
-                            self.viewModel.loginWithContinueWithoutTumID()
-                            self.viewModel.model?.isLoginSheetPresented = false
-                        }) {
-                            Text("Continue without TUM ID").lineLimit(1).font(.caption)
-                                .frame(alignment: .center)
-                        }
-                        .alert("Login Error", isPresented: self.$showLoginAlert) {
-                            Button("OK", role: .cancel) {}
-                        }
-                        .aspectRatio(contentMode: .fill)
-                        .font(.subheadline)
                     }
-                    .frame(width: geo.size.width, height: geo.size.height / 4 )
+                    .disabled(!viewModel.isContinueEnabled)
+                    .lineLimit(1)
+                    .font(.body)
+                    .frame(width: 200, height: 48, alignment: .center)
+                    .foregroundColor(.white)
+                    .background(buttonBackgroundColor)
+                    .cornerRadius(10)
+                    .buttonStyle(.plain)
+                    .alert("Login Error", isPresented: self.$showLoginAlert) {
+                        Button("OK", role: .cancel) {}
+                    }
+                    .aspectRatio(contentMode: .fill)
+                    .font(.subheadline)
                     
-                    Spacer()
-                        
-                    Image(decorative: "tower")
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: geo.size.width)
-                        
+                    Spacer().frame(height: 20)
                     
-                    Spacer()
                     
+                    Button(action: {
+                        self.viewModel.loginWithContinueWithoutTumID()
+                        self.viewModel.model?.isLoginSheetPresented = false
+                    }) {
+                        Text("Continue without TUM ID").lineLimit(1).font(.caption)
+                            .frame(alignment: .center)
+                    }
+                    .alert("Login Error", isPresented: self.$showLoginAlert) {
+                        Button("OK", role: .cancel) {}
+                    }
+                    .aspectRatio(contentMode: .fill)
+                    .font(.subheadline)
                 }
+                .frame(width: geo.size.width, height: geo.size.height / 4 )
+                
+                Spacer()
+                
+                Image(decorative: "tower")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: geo.size.width)
+                
+                
+                Spacer()
+                
             }
-            .navigationBarHidden(true)
-            .ignoresSafeArea(.keyboard)
+        }
+        .navigationBarHidden(true)
+        .ignoresSafeArea(.keyboard)
     }
     
     init(model: Model) {
         self.viewModel = LoginViewModel(model: model)
-//        KeychainService.removeAuthorization()
+        //        KeychainService.removeAuthorization()
     }
 }
 
@@ -220,9 +203,9 @@ struct LoginView_Previews: PreviewProvider {
                 LoginView(model: model).navigationBarHidden(true)
             }
         }
-//        .previewDevice("iPad Pro (12.9 inch) (5th generation)")
-//        .previewInterfaceOrientation(.landscapeRight)
-//        .previewDevice("iPod touch (7th generation)")
+        //        .previewDevice("iPad Pro (12.9 inch) (5th generation)")
+        //        .previewInterfaceOrientation(.landscapeRight)
+        //        .previewDevice("iPod touch (7th generation)")
         .previewDevice("iPhone 12")
         .previewInterfaceOrientation(.portrait)
         

--- a/Campus-iOS/MoviesComponent/Views/MovieCard.swift
+++ b/Campus-iOS/MoviesComponent/Views/MovieCard.swift
@@ -27,7 +27,7 @@ struct MovieCard: View {
                             .frame(width: 390 * 0.425, height: 390 * 0.6)
                             .clipped()
                     case .failure:
-                        Image("movie")
+                        Image(decorative: "movie")
                             .resizable()
                             .frame(minWidth: nil, idealWidth: nil, maxWidth: UIScreen.main.bounds.width, minHeight: nil, idealHeight: nil, maxHeight: UIScreen.main.bounds.height, alignment: .center)
                             .clipped()
@@ -41,7 +41,7 @@ struct MovieCard: View {
                 }
                 
             } else {
-                Image("movie")
+                Image(decorative: "movie")
                     .resizable()
                     .frame(minWidth: nil, idealWidth: nil, maxWidth: UIScreen.main.bounds.width, minHeight: nil, idealHeight: nil, maxHeight: UIScreen.main.bounds.height, alignment: .center)
                     .clipped()

--- a/Campus-iOS/MoviesComponent/Views/MovieDetailedView.swift
+++ b/Campus-iOS/MoviesComponent/Views/MovieDetailedView.swift
@@ -44,7 +44,7 @@ struct MovieDetailedView: View {
                                             .offset(y: -geometry.frame(in: .global).minY)
                                     }
                                 case .failure:
-                                    Image("movie")
+                                    Image(decorative: "movie")
                                         .resizable()
                                         .frame(minWidth: nil, idealWidth: nil, maxWidth: UIScreen.main.bounds.width, minHeight: nil, idealHeight: nil, maxHeight: UIScreen.main.bounds.height, alignment: .center)
                                         .clipped()
@@ -57,7 +57,7 @@ struct MovieDetailedView: View {
                                 }
                             }
                         } else {
-                            Image("movie")
+                            Image(decorative: "movie")
                                 .resizable()
                                 .scaledToFit()
                                 .frame(height: 120, alignment: .top)

--- a/Campus-iOS/ProfileComponent/View/ProfileView.swift
+++ b/Campus-iOS/ProfileComponent/View/ProfileView.swift
@@ -116,20 +116,27 @@ struct ProfileView: View {
                         Button("Join Beta") {
                             self.selectedLink = URL(string: "https://testflight.apple.com/join/4Ddi6f2f")
                         }
+                        .accessibilityHint("This Button opens a WebView")
                         
                         Button("TUM Dev on Github") {
                             self.selectedLink = URL(string: "https://github.com/TUM-Dev")
                         }
+                        .accessibilityHint("This Button opens a WebView")
                         
                         Button("TUM Dev Website") {
                             self.selectedLink = URL(string: "https://tum.app")
                         }
+                        .accessibilityHint("This Button opens a WebView")
+                        
                     } else {
                         Link(LocalizedStringKey("Join Beta"), destination: URL(string: "https://testflight.apple.com/join/4Ddi6f2f")!)
+                            .accessibilityHint("This Link leaves the App")
                         
                         Link(LocalizedStringKey("TUM Dev on Github"), destination: URL(string: "https://github.com/TUM-Dev")!)
+                            .accessibilityHint("This Link leaves the App")
                         
                         Link("TUM Dev Website", destination: URL(string: "https://tum.app")!)
+                            .accessibilityHint("This Link leaves the App")
                     }
                     
                     Button("Feedback") {

--- a/Campus-iOS/ProfileComponent/View/ProfileView.swift
+++ b/Campus-iOS/ProfileComponent/View/ProfileView.swift
@@ -138,7 +138,7 @@ struct ProfileView: View {
                         if UIApplication.shared.canOpenURL(mailToUrl) {
                                 UIApplication.shared.open(mailToUrl, options: [:])
                         }
-                    }
+                    }.accessibilityHint("This Link leaves the App")
                 }
                 
                 Section() {

--- a/Campus-iOS/TUMSexyComponent/Views/TUMSexyView.swift
+++ b/Campus-iOS/TUMSexyComponent/Views/TUMSexyView.swift
@@ -15,22 +15,27 @@ struct TUMSexyView: View {
     @State private var searchText = ""
     
     var body: some View {
-        List(searchResults, id: \.target) { link in
+        List(searchResults.indices , id: \.self) { idx in
             if useBuildInWebView {
-                Text(link.description ?? "")
+                Text(searchResults[idx].description ?? "")
                     .foregroundColor(.blue)
                     .onTapGesture {
                         isWebViewShowed.toggle()
                     }
                     .sheet(isPresented: $isWebViewShowed, content: {
-                        SFSafariViewWrapper(url: URL(string: link.target ?? "")!)
+                        SFSafariViewWrapper(url: URL(string: searchResults[idx].target ?? "")!)
                     })
+                    .accessibilityLabel("List element" + "\(idx + 1)" + " of " + "\(searchResults.count)")
+                    .accessibilityHint("This Button opens a WebView")
             } else {
-                Link(link.description ?? "", destination: URL(string: link.target ?? "")!)
+                Link(searchResults[idx].description ?? "", destination: URL(string: searchResults[idx].target ?? "")!)
+                    .accessibilityLabel("List element" + "\(idx + 1)" + " of " + "\(searchResults.count)")
+                    .accessibilityHint("This Link leaves the App")
             }
         }
         .searchable(text: $searchText)
         .navigationTitle("Useful Links")
+        .accessibilityLabel("This is a list with " + "\(searchResults.count)" + " entries")
     }
     
     var searchResults: [TUMSexyLink] {


### PR DESCRIPTION
### Issue
This PR relates to the [accessibility report](https://app.caat.report/share/c88fd84f-76c0-11ed-8777-c2c48c739db8#9b0544f4-7564-11ed-8777-c2c48c739db8__f6a432fb-6a7d-4dbc-9dd1-bd73a123afc7) and solves the first batch of issues. For detailed view on the cuurent status of the issues in this report checkout this [notion page](https://www.notion.so/Accessibility-Report-d0bfdbe1945749d68dfd693bad3fbd0c?pvs=4). 

This fixes the following issue(s): 

1. Updated decorative Images with `Image(decorative: “ImageTitle”)` so Screenreaders don't read them
2. Had to change the Error in the LoginView to an alert -> for accessibility reasons error messages aren't allowed to automatically disappear (-> checkout screenshot)
3. Added `.accessibilityHeading()` to Headings -> Screenreaders now knows if heading is h1, h2, h3 etc
4. Using `.accessibilityHint()` the App now notifies users with active Screenreader that a certain links leaves the app (-> email link for support)
5. In the TUM.sexy view the screen readers now adds the "link" to every button -> this was done using `.accessibilityHint()` + also added this to every other Link in TCA
6. Added Screereader descriptions for the List in the TUM.sexy view -> Now the Screenreader describes the length of the list and for every element in the lists adds the position e.g. "Element 2 of 3" -> _note: this solves the issue in the report but in theory should be added to every list in TCA_

### Screenshots
<img src="https://user-images.githubusercontent.com/62808178/224719221-3769872a-f00a-4d52-92a6-611188e1f0e8.png"  height="400">

